### PR TITLE
- fixed a bug where you had a cooldown issue on skills learned using …

### DIFF
--- a/Server/MirDatabase/MagicInfo.cs
+++ b/Server/MirDatabase/MagicInfo.cs
@@ -18,6 +18,7 @@ namespace Server.MirDatabase
         public uint DelayBase = 1800, DelayReduction;
         public ushort PowerBase, PowerBonus;
         public ushort MPowerBase, MPowerBonus;
+        public float MultiplierBase = 1.0f, MultiplierBonus;
         public byte Range = 9;
 
         public override string ToString()
@@ -52,6 +53,11 @@ namespace Server.MirDatabase
 
             if (version > 66)
                 Range = reader.ReadByte();
+            if (version > 70)
+            {
+                MultiplierBase = reader.ReadSingle();
+                MultiplierBonus = reader.ReadSingle();
+            }
         }
 
         public void Save(BinaryWriter writer)
@@ -74,6 +80,8 @@ namespace Server.MirDatabase
             writer.Write(MPowerBase);
             writer.Write(MPowerBonus);
             writer.Write(Range);
+            writer.Write(MultiplierBase);
+            writer.Write(MultiplierBonus);
         }
     }
 
@@ -158,10 +166,19 @@ namespace Server.MirDatabase
                     IsTempSpell = IsTempSpell,
                     Delay = GetDelay(),
                     Range = Info.Range,
-                    CastTime = SMain.Envir.Time > CastTime? SMain.Envir.Time - CastTime: 0
+                    CastTime = (CastTime != 0) && (SMain.Envir.Time > CastTime)? SMain.Envir.Time - CastTime: 0
             };
         }
 
+        public int GetDamage(int DamageBase)
+        {
+            return (int)((DamageBase + GetPower()) * GetMultiplier());
+        }
+
+        public float GetMultiplier()
+        {
+            return (Info.MultiplierBase + (Level * Info.MultiplierBonus));
+        }
 
         public int GetPower()
         {

--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -54,7 +54,7 @@ namespace Server.MirEnvir
         public static object AccountLock = new object();
         public static object LoadLock = new object();
 
-        public const int Version = 70;
+        public const int Version = 71;
         public const int CustomVersion = 0;
         public const string DatabasePath = @".\Server.MirDB";
         public const string AccountPath = @".\Server.MirADB";
@@ -211,30 +211,114 @@ namespace Server.MirEnvir
             return false;
         }
 
+        private void UpdateMagicInfo()
+        {
+            for (int i = 0; i < MagicInfoList.Count; i++)
+            {
+                switch(MagicInfoList[i].Spell)
+                {
+                        //warrior
+                    case Spell.Thrusting:
+                        MagicInfoList[i].MultiplierBase = 0.25f;
+                        MagicInfoList[i].MultiplierBonus = 0.25f;
+                        break;
+                    case Spell.HalfMoon:
+                        MagicInfoList[i].MultiplierBase = 0.3f;
+                        MagicInfoList[i].MultiplierBonus = 0.1f;
+                        break;
+                    case Spell.ShoulderDash:
+                        MagicInfoList[i].MPowerBase = 4;
+                        break;
+                    case Spell.TwinDrakeBlade:
+                        MagicInfoList[i].MultiplierBase = 0.8f;
+                        MagicInfoList[i].MultiplierBonus = 0.1f;
+                        break;
+                    case Spell.FlamingSword:
+                        MagicInfoList[i].MultiplierBase = 1.4f;
+                        MagicInfoList[i].MultiplierBonus = 0.4f;
+                        break;
+                    case Spell.CrossHalfMoon:
+                        MagicInfoList[i].MultiplierBase = 0.4f;
+                        MagicInfoList[i].MultiplierBonus = 0.1f;
+                        break;
+                    case Spell.BladeAvalanche:
+                        MagicInfoList[i].MultiplierBase = 1f;
+                        MagicInfoList[i].MultiplierBonus = 0.4f;
+                        break;
+                    case Spell.SlashingBurst:
+                        MagicInfoList[i].MultiplierBase = 3.25f;
+                        MagicInfoList[i].MultiplierBonus = 0.25f;
+                        break;
+                        //wiz
+                    case Spell.Repulsion:
+                        MagicInfoList[i].MPowerBase = 4;
+                        break;
+                        //tao
+                    case Spell.Poisoning:
+                        MagicInfoList[i].MPowerBase = 0;
+                        break;
+                    case Spell.Curse:
+                        MagicInfoList[i].MPowerBase = 20;
+                        break;
+                    case Spell.Plague:
+                        MagicInfoList[i].MPowerBase = 0;
+                        MagicInfoList[i].PowerBase = 0;
+                        break;
+                        //sin
+                    case Spell.FatalSword:
+                        MagicInfoList[i].MPowerBase = 20;
+                        break;
+                    case Spell.DoubleSlash:
+                        MagicInfoList[i].MultiplierBase = 0.8f;
+                        MagicInfoList[i].MultiplierBonus = 0.1f;
+                        break;
+                    case Spell.FireBurst:
+                        MagicInfoList[i].MPowerBase = 4;
+                        break;
+                    case Spell.MoonLight:
+                        MagicInfoList[i].MPowerBase = 20;
+                        break;
+                    case Spell.DarkBody:
+                        MagicInfoList[i].MPowerBase = 20;
+                        break;
+                    case Spell.Hemorrhage:
+                        MagicInfoList[i].MultiplierBase = 0.2f;
+                        MagicInfoList[i].MultiplierBonus = 0.05f;
+                        break;
+                    case Spell.CrescentSlash:
+                        MagicInfoList[i].MultiplierBase = 1f;
+                        MagicInfoList[i].MultiplierBonus = 0.4f;
+                        break;
+                        //archer
+                        //no changes :p
+                }
+            }
+        }
+
         private void FillMagicInfoList()
         {
             //Warrior
             if (!MagicExists(Spell.Fencing)) MagicInfoList.Add(new MagicInfo {Name = "Fencing", Spell = Spell.Fencing, Icon = 2, Level1 = 7, Level2 = 9, Level3 = 12, Need1 = 270, Need2 = 600, Need3 = 1300, Range = 0 });
             if (!MagicExists(Spell.Slaying)) MagicInfoList.Add(new MagicInfo { Name = "Slaying", Spell = Spell.Slaying, Icon = 6, Level1 = 15, Level2 = 17, Level3 = 20, Need1 = 500, Need2 = 1100, Need3 = 1800, Range = 0 });
-            if (!MagicExists(Spell.Thrusting)) MagicInfoList.Add(new MagicInfo { Name = "Thrusting", Spell = Spell.Thrusting, Icon = 11, Level1 = 22, Level2 = 24, Level3 = 27, Need1 = 2000, Need2 = 3500, Need3 = 6000, Range = 0 });
-            if (!MagicExists(Spell.HalfMoon)) MagicInfoList.Add(new MagicInfo { Name = "HalfMoon", Spell = Spell.HalfMoon, Icon = 24, Level1 = 26, Level2 = 28, Level3 = 31, Need1 = 5000, Need2 = 8000, Need3 = 14000, BaseCost = 3, Range = 0 });
-            if (!MagicExists(Spell.ShoulderDash)) MagicInfoList.Add(new MagicInfo { Name = "ShoulderDash", Spell = Spell.ShoulderDash, Icon = 26, Level1 = 30, Level2 = 32, Level3 = 34, Need1 = 3000, Need2 = 4000, Need3 = 6000, BaseCost = 4, LevelCost = 4, DelayBase = 2500, Range = 0 });
-            if (!MagicExists(Spell.TwinDrakeBlade)) MagicInfoList.Add(new MagicInfo { Name = "TwinDrakeBlade", Spell = Spell.TwinDrakeBlade, Icon = 37, Level1 = 32, Level2 = 34, Level3 = 37, Need1 = 4000, Need2 = 6000, Need3 = 10000, BaseCost = 10, Range = 0 });
+            if (!MagicExists(Spell.Thrusting)) MagicInfoList.Add(new MagicInfo { Name = "Thrusting", Spell = Spell.Thrusting, Icon = 11, Level1 = 22, Level2 = 24, Level3 = 27, Need1 = 2000, Need2 = 3500, Need3 = 6000, Range = 0, MultiplierBase = 0.25f, MultiplierBonus = 0.25f });
+            if (!MagicExists(Spell.HalfMoon)) MagicInfoList.Add(new MagicInfo { Name = "HalfMoon", Spell = Spell.HalfMoon, Icon = 24, Level1 = 26, Level2 = 28, Level3 = 31, Need1 = 5000, Need2 = 8000, Need3 = 14000, BaseCost = 3, Range = 0, MultiplierBase =0.3f, MultiplierBonus = 0.1f });
+            if (!MagicExists(Spell.ShoulderDash)) MagicInfoList.Add(new MagicInfo { Name = "ShoulderDash", Spell = Spell.ShoulderDash, Icon = 26, Level1 = 30, Level2 = 32, Level3 = 34, Need1 = 3000, Need2 = 4000, Need3 = 6000, BaseCost = 4, LevelCost = 4, DelayBase = 2500, Range = 0 , MPowerBase = 4});
+            if (!MagicExists(Spell.TwinDrakeBlade)) MagicInfoList.Add(new MagicInfo { Name = "TwinDrakeBlade", Spell = Spell.TwinDrakeBlade, Icon = 37, Level1 = 32, Level2 = 34, Level3 = 37, Need1 = 4000, Need2 = 6000, Need3 = 10000, BaseCost = 10, Range = 0 , MultiplierBase = 0.8f, MultiplierBonus = 0.1f});
             if (!MagicExists(Spell.Entrapment)) MagicInfoList.Add(new MagicInfo { Name = "Entrapment", Spell = Spell.Entrapment, Icon = 46, Level1 = 32, Level2 = 35, Level3 = 37, Need1 = 2000, Need2 = 3500, Need3 = 5500, BaseCost = 15, LevelCost = 3, Range = 9 });
-            if (!MagicExists(Spell.FlamingSword)) MagicInfoList.Add(new MagicInfo { Name = "FlamingSword", Spell = Spell.FlamingSword, Icon = 25, Level1 = 35, Level2 = 37, Level3 = 40, Need1 = 2000, Need2 = 4000, Need3 = 6000, BaseCost = 7, Range = 0 });
+            if (!MagicExists(Spell.FlamingSword)) MagicInfoList.Add(new MagicInfo { Name = "FlamingSword", Spell = Spell.FlamingSword, Icon = 25, Level1 = 35, Level2 = 37, Level3 = 40, Need1 = 2000, Need2 = 4000, Need3 = 6000, BaseCost = 7, Range = 0, MultiplierBase = 1.4f, MultiplierBonus = 0.4f});
             if (!MagicExists(Spell.LionRoar)) MagicInfoList.Add(new MagicInfo { Name = "LionRoar", Spell = Spell.LionRoar, Icon = 42, Level1 = 36, Level2 = 39, Level3 = 41, Need1 = 5000, Need2 = 8000, Need3 = 12000, BaseCost = 14, LevelCost = 4, Range = 0 });
-            if (!MagicExists(Spell.CrossHalfMoon)) MagicInfoList.Add(new MagicInfo { Name = "CrossHalfMoon", Spell = Spell.CrossHalfMoon, Icon = 33, Level1 = 38, Level2 = 40, Level3 = 42, Need1 = 7000, Need2 = 11000, Need3 = 16000, BaseCost = 6, Range = 0 });
-            if (!MagicExists(Spell.BladeAvalanche)) MagicInfoList.Add(new MagicInfo { Name = "BladeAvalanche", Spell = Spell.BladeAvalanche, Icon = 43, Level1 = 38, Level2 = 41, Level3 = 43, Need1 = 5000, Need2 = 8000, Need3 = 12000, BaseCost = 14, LevelCost = 4, Range = 0 });
+            if (!MagicExists(Spell.CrossHalfMoon)) MagicInfoList.Add(new MagicInfo { Name = "CrossHalfMoon", Spell = Spell.CrossHalfMoon, Icon = 33, Level1 = 38, Level2 = 40, Level3 = 42, Need1 = 7000, Need2 = 11000, Need3 = 16000, BaseCost = 6, Range = 0, MultiplierBase = 0.4f, MultiplierBonus = 0.1f });
+            if (!MagicExists(Spell.BladeAvalanche)) MagicInfoList.Add(new MagicInfo { Name = "BladeAvalanche", Spell = Spell.BladeAvalanche, Icon = 43, Level1 = 38, Level2 = 41, Level3 = 43, Need1 = 5000, Need2 = 8000, Need3 = 12000, BaseCost = 14, LevelCost = 4, Range = 0, MultiplierBonus = 0.3f});
             if (!MagicExists(Spell.ProtectionField)) MagicInfoList.Add(new MagicInfo { Name = "ProtectionField", Spell = Spell.ProtectionField, Icon = 50, Level1 = 39, Level2 = 42, Level3 = 45, Need1 = 6000, Need2 = 12000, Need3 = 18000, BaseCost = 23, LevelCost = 6, Range = 0 });
             if (!MagicExists(Spell.Rage)) MagicInfoList.Add(new MagicInfo { Name = "Rage", Spell = Spell.Rage, Icon = 49, Level1 = 44, Level2 = 47, Level3 = 50, Need1 = 8000, Need2 = 14000, Need3 = 20000, BaseCost = 20, LevelCost = 5, Range = 0 });
-            if (!MagicExists(Spell.CounterAttack)) MagicInfoList.Add(new MagicInfo { Name = "CounterAttack", Spell = Spell.CounterAttack, Icon = 72, Level1 = 47, Level2 = 51, Level3 = 55, Need1 = 7000, Need2 = 11000, Need3 = 15000, BaseCost = 12, LevelCost = 4, DelayBase = 24000, Range = 0 });
-            if (!MagicExists(Spell.SlashingBurst)) MagicInfoList.Add(new MagicInfo { Name = "SlashingBurst", Spell = Spell.SlashingBurst, Icon = 55, Level1 = 50, Level2 = 53, Level3 = 56, Need1 = 10000, Need2 = 16000, Need3 = 24000, BaseCost = 25, LevelCost = 4, MPowerBase = 1, PowerBase = 3, DelayBase = 14000, DelayReduction = 4000, Range = 0 });
+            if (!MagicExists(Spell.CounterAttack)) MagicInfoList.Add(new MagicInfo { Name = "CounterAttack", Spell = Spell.CounterAttack, Icon = 72, Level1 = 47, Level2 = 51, Level3 = 55, Need1 = 7000, Need2 = 11000, Need3 = 15000, BaseCost = 12, LevelCost = 4, DelayBase = 24000, Range = 0 , MultiplierBonus = 0.4f});
+            if (!MagicExists(Spell.SlashingBurst)) MagicInfoList.Add(new MagicInfo { Name = "SlashingBurst", Spell = Spell.SlashingBurst, Icon = 55, Level1 = 50, Level2 = 53, Level3 = 56, Need1 = 10000, Need2 = 16000, Need3 = 24000, BaseCost = 25, LevelCost = 4, MPowerBase = 1, PowerBase = 3, DelayBase = 14000, DelayReduction = 4000, Range = 0 , MultiplierBase = 3.25f, MultiplierBonus = 0.25f});
             if (!MagicExists(Spell.Fury)) MagicInfoList.Add(new MagicInfo { Name = "Fury", Spell = Spell.Fury, Icon = 76, Level1 = 45, Level2 = 48, Level3 = 51, Need1 = 8000, Need2 = 14000, Need3 = 20000, BaseCost = 10, LevelCost = 4, DelayBase = 600000, DelayReduction = 120000, Range = 0 });
             if (!MagicExists(Spell.ImmortalSkin)) MagicInfoList.Add(new MagicInfo { Name = "ImmortalSkin", Spell = Spell.ImmortalSkin, Icon = 80, Level1 = 60, Level2 = 61, Level3 = 62, Need1 = 1560, Need2 = 2200, Need3 = 3000, BaseCost = 10, LevelCost = 4, DelayBase = 600000, DelayReduction = 120000, Range = 0 });
 
             //Wizard
             if (!MagicExists(Spell.FireBall)) MagicInfoList.Add(new MagicInfo { Name = "FireBall", Spell = Spell.FireBall, Icon = 0, Level1 = 7, Level2 = 9, Level3 = 11, Need1 = 200, Need2 = 350, Need3 = 700, BaseCost = 3, LevelCost = 2, MPowerBase = 8, PowerBase = 2, Range = 9 });
-            if (!MagicExists(Spell.Repulsion)) MagicInfoList.Add(new MagicInfo { Name = "Repulsion", Spell = Spell.Repulsion, Icon = 7, Level1 = 12, Level2 = 15, Level3 = 19, Need1 = 500, Need2 = 1300, Need3 = 2200, BaseCost = 2, LevelCost = 2, Range = 0 });
+            if (!MagicExists(Spell.Repulsion)) MagicInfoList.Add(new MagicInfo { Name = "Repulsion", Spell = Spell.Repulsion, Icon = 7, Level1 = 12, Level2 = 15, Level3 = 19, Need1 = 500, Need2 = 1300, Need3 = 2200, BaseCost = 2, LevelCost = 2, Range = 0, MPowerBase = 4});
             if (!MagicExists(Spell.ElectricShock)) MagicInfoList.Add(new MagicInfo { Name = "ElectricShock", Spell = Spell.ElectricShock, Icon = 19, Level1 = 13, Level2 = 18, Level3 = 24, Need1 = 530, Need2 = 1100, Need3 = 2200, BaseCost = 3, LevelCost = 1, Range = 9 });
             if (!MagicExists(Spell.GreatFireBall)) MagicInfoList.Add(new MagicInfo { Name = "GreatFireBall", Spell = Spell.GreatFireBall, Icon = 4, Level1 = 15, Level2 = 18, Level3 = 21, Need1 = 2000, Need2 = 2700, Need3 = 3500, BaseCost = 5, LevelCost = 1, MPowerBase = 6, PowerBase = 10, Range = 9 });
             if (!MagicExists(Spell.HellFire)) MagicInfoList.Add(new MagicInfo { Name = "HellFire", Spell = Spell.HellFire, Icon = 8, Level1 = 16, Level2 = 20, Level3 = 24, Need1 = 700, Need2 = 2700, Need3 = 3500, BaseCost = 10, LevelCost = 3, MPowerBase = 14, PowerBase = 6, Range = 0 });
@@ -264,7 +348,7 @@ namespace Server.MirEnvir
             //Taoist
             if (!MagicExists(Spell.Healing)) MagicInfoList.Add(new MagicInfo { Name = "Healing", Spell = Spell.Healing, Icon = 1, Level1 = 7, Level2 = 11, Level3 = 14, Need1 = 150, Need2 = 350, Need3 = 700, BaseCost = 3, LevelCost = 2, MPowerBase = 14, Range = 9 });
             if (!MagicExists(Spell.SpiritSword)) MagicInfoList.Add(new MagicInfo { Name = "SpiritSword", Spell = Spell.SpiritSword, Icon = 3, Level1 = 9, Level2 = 12, Level3 = 15, Need1 = 350, Need2 = 1300, Need3 = 2700, Range = 0 });
-            if (!MagicExists(Spell.Poisoning)) MagicInfoList.Add(new MagicInfo { Name = "Poisoning", Spell = Spell.Poisoning, Icon = 5, Level1 = 14, Level2 = 17, Level3 = 20, Need1 = 700, Need2 = 1300, Need3 = 2700, BaseCost = 2, LevelCost = 1, MPowerBase = 6, Range = 9 });
+            if (!MagicExists(Spell.Poisoning)) MagicInfoList.Add(new MagicInfo { Name = "Poisoning", Spell = Spell.Poisoning, Icon = 5, Level1 = 14, Level2 = 17, Level3 = 20, Need1 = 700, Need2 = 1300, Need3 = 2700, BaseCost = 2, LevelCost = 1, Range = 9 });
             if (!MagicExists(Spell.SoulFireBall)) MagicInfoList.Add(new MagicInfo { Name = "SoulFireBall", Spell = Spell.SoulFireBall, Icon = 12, Level1 = 18, Level2 = 21, Level3 = 24, Need1 = 1300, Need2 = 2700, Need3 = 4000, BaseCost = 3, LevelCost = 1, MPowerBase = 8, PowerBase = 3, Range = 9 });
             if (!MagicExists(Spell.SummonSkeleton)) MagicInfoList.Add(new MagicInfo { Name = "SummonSkeleton", Spell = Spell.SummonSkeleton, Icon = 16, Level1 = 19, Level2 = 22, Level3 = 26, Need1 = 1000, Need2 = 2000, Need3 = 3500, BaseCost = 12, LevelCost = 4, Range = 0 });
             if (!MagicExists(Spell.Hiding)) MagicInfoList.Add(new MagicInfo { Name = "Hiding", Spell = Spell.Hiding, Icon = 17, Level1 = 20, Level2 = 23, Level3 = 26, Need1 = 1300, Need2 = 2700, Need3 = 5300, BaseCost = 1, LevelCost = 1, Range = 0 });
@@ -272,7 +356,7 @@ namespace Server.MirEnvir
             if (!MagicExists(Spell.SoulShield)) MagicInfoList.Add(new MagicInfo { Name = "SoulShield", Spell = Spell.SoulShield, Icon = 13, Level1 = 22, Level2 = 24, Level3 = 26, Need1 = 2000, Need2 = 3500, Need3 = 7000, BaseCost = 2, LevelCost = 2, Range = 9 });
             if (!MagicExists(Spell.Revelation)) MagicInfoList.Add(new MagicInfo { Name = "Revelation", Spell = Spell.Revelation, Icon = 27, Level1 = 23, Level2 = 25, Level3 = 28, Need1 = 1500, Need2 = 2500, Need3 = 4000, BaseCost = 4, LevelCost = 4, Range = 9 });
             if (!MagicExists(Spell.BlessedArmour)) MagicInfoList.Add(new MagicInfo { Name = "BlessedArmour", Spell = Spell.BlessedArmour, Icon = 14, Level1 = 25, Level2 = 27, Level3 = 29, Need1 = 4000, Need2 = 6000, Need3 = 10000, BaseCost = 2, LevelCost = 2, Range = 9 });
-            if (!MagicExists(Spell.EnergyRepulsor)) MagicInfoList.Add(new MagicInfo { Name = "EnergyRepulsor", Spell = Spell.EnergyRepulsor, Icon = 36, Level1 = 27, Level2 = 29, Level3 = 31, Need1 = 1800, Need2 = 2400, Need3 = 3200, BaseCost = 2, LevelCost = 2, Range = 0 });
+            if (!MagicExists(Spell.EnergyRepulsor)) MagicInfoList.Add(new MagicInfo { Name = "EnergyRepulsor", Spell = Spell.EnergyRepulsor, Icon = 36, Level1 = 27, Level2 = 29, Level3 = 31, Need1 = 1800, Need2 = 2400, Need3 = 3200, BaseCost = 2, LevelCost = 2, Range = 0, MPowerBase = 4 });
             if (!MagicExists(Spell.TrapHexagon)) MagicInfoList.Add(new MagicInfo { Name = "TrapHexagon", Spell = Spell.TrapHexagon, Icon = 15, Level1 = 28, Level2 = 30, Level3 = 32, Need1 = 2500, Need2 = 5000, Need3 = 10000, BaseCost = 7, LevelCost = 3, Range = 9 });
             if (!MagicExists(Spell.Purification)) MagicInfoList.Add(new MagicInfo { Name = "Purification", Spell = Spell.Purification, Icon = 39, Level1 = 30, Level2 = 32, Level3 = 35, Need1 = 3000, Need2 = 5000, Need3 = 8000, BaseCost = 14, LevelCost = 2, Range = 9 });
             if (!MagicExists(Spell.MassHealing)) MagicInfoList.Add(new MagicInfo { Name = "MassHealing", Spell = Spell.MassHealing, Icon = 28, Level1 = 31, Level2 = 33, Level3 = 36, Need1 = 2000, Need2 = 4000, Need3 = 8000, BaseCost = 28, LevelCost = 3, MPowerBase = 10, PowerBase = 4, Range = 9 });
@@ -281,8 +365,8 @@ namespace Server.MirEnvir
             if (!MagicExists(Spell.SummonShinsu)) MagicInfoList.Add(new MagicInfo { Name = "SummonShinsu", Spell = Spell.SummonShinsu, Icon = 29, Level1 = 35, Level2 = 37, Level3 = 40, Need1 = 2000, Need2 = 4000, Need3 = 6000, BaseCost = 28, LevelCost = 4, Range = 0 });
             if (!MagicExists(Spell.Reincarnation)) MagicInfoList.Add(new MagicInfo { Name = "Reincarnation", Spell = Spell.Reincarnation, Icon = 53, Level1 = 37, Level2 = 39, Level3 = 41, Need1 = 2000, Need2 = 6000, Need3 = 10000, BaseCost = 125, LevelCost = 17, Range = 9 });
             if (!MagicExists(Spell.SummonHolyDeva)) MagicInfoList.Add(new MagicInfo { Name = "SummonHolyDeva", Spell = Spell.SummonHolyDeva, Icon = 40, Level1 = 38, Level2 = 41, Level3 = 43, Need1 = 4000, Need2 = 6000, Need3 = 9000, BaseCost = 28, LevelCost = 4, Range = 0 });
-            if (!MagicExists(Spell.Curse)) MagicInfoList.Add(new MagicInfo { Name = "Curse", Spell = Spell.Curse, Icon = 45, Level1 = 40, Level2 = 42, Level3 = 44, Need1 = 4000, Need2 = 6000, Need3 = 9000, BaseCost = 17, LevelCost = 3, Range = 9 });
-            if (!MagicExists(Spell.Plague)) MagicInfoList.Add(new MagicInfo { Name = "Plague", Spell = Spell.Plague, Icon = 74, Level1 = 42, Level2 = 44, Level3 = 47, Need1 = 5000, Need2 = 9000, Need3 = 13000, BaseCost = 20, LevelCost = 5, MPowerBase = 10, PowerBase = 8, Range = 9 });
+            if (!MagicExists(Spell.Curse)) MagicInfoList.Add(new MagicInfo { Name = "Curse", Spell = Spell.Curse, Icon = 45, Level1 = 40, Level2 = 42, Level3 = 44, Need1 = 4000, Need2 = 6000, Need3 = 9000, BaseCost = 17, LevelCost = 3, Range = 9, MPowerBase = 20 });
+            if (!MagicExists(Spell.Plague)) MagicInfoList.Add(new MagicInfo { Name = "Plague", Spell = Spell.Plague, Icon = 74, Level1 = 42, Level2 = 44, Level3 = 47, Need1 = 5000, Need2 = 9000, Need3 = 13000, BaseCost = 20, LevelCost = 5, Range = 9 });
             if (!MagicExists(Spell.PoisonCloud)) MagicInfoList.Add(new MagicInfo { Name = "PoisonCloud", Spell = Spell.PoisonCloud, Icon = 54, Level1 = 43, Level2 = 45, Level3 = 48, Need1 = 4000, Need2 = 8000, Need3 = 12000, BaseCost = 30, LevelCost = 5, MPowerBase = 40, PowerBase = 20, DelayBase = 18000, DelayReduction = 2000, Range = 9 });
             if (!MagicExists(Spell.EnergyShield)) MagicInfoList.Add(new MagicInfo { Name = "EnergyShield", Spell = Spell.EnergyShield, Icon = 57, Level1 = 48, Level2 = 51, Level3 = 54, Need1 = 5000, Need2 = 9000, Need3 = 13000, BaseCost = 50, LevelCost = 20, Range = 9 });
             if (!MagicExists(Spell.PetEnhancer)) MagicInfoList.Add(new MagicInfo { Name = "PetEnhancer", Spell = Spell.PetEnhancer, Icon = 78, Level1 = 45, Level2 = 48, Level3 = 51, Need1 = 4000, Need2 = 8000, Need3 = 12000, BaseCost = 30, LevelCost = 40, Range = 0 });
@@ -1165,6 +1249,8 @@ namespace Server.MirEnvir
                             MagicInfoList.Add(new MagicInfo(reader, LoadVersion, LoadCustomVersion));
                     }
                     FillMagicInfoList();
+                    if (LoadVersion <= 70)
+                        UpdateMagicInfo();
 
                     if (LoadVersion >= 63)
                     {

--- a/Server/MirEnvir/Map.cs
+++ b/Server/MirEnvir/Map.cs
@@ -1277,9 +1277,8 @@ namespace Server.MirEnvir
                         location = (Point)data[2];
                         MirDirection direction = (MirDirection)data[3];
 
-                        int criticalDamage = (int)data[4];
-                        int nearDamage = (int)data[5];
-                        int farDamage = (int)data[6];
+                        int nearDamage = (int)data[4];
+                        int farDamage = (int)data[5];
 
                         int col = 3;
                         int row = 3;

--- a/Server/MirForms/Database/MagicInfoForm.Designer.cs
+++ b/Server/MirForms/Database/MagicInfoForm.Designer.cs
@@ -38,7 +38,6 @@
         private System.Windows.Forms.Label label12;
         private System.Windows.Forms.Panel panel4;
         private System.Windows.Forms.Label label15;
-        private System.Windows.Forms.Panel panel5;
         private System.Windows.Forms.Label lblDamageExample;
         private System.Windows.Forms.TextBox txtDmgBonusMax;
         private System.Windows.Forms.TextBox txtDmgBonusMin;
@@ -51,5 +50,10 @@
         private System.Windows.Forms.Label lblSelected;
         private System.Windows.Forms.Label label20;
         private System.Windows.Forms.TextBox txtRange;
+        private System.Windows.Forms.Label lblDamageExplained;
+        private System.Windows.Forms.TextBox txtDmgMultBoost;
+        private System.Windows.Forms.TextBox txtDmgMultBase;
+        private System.Windows.Forms.Label label21;
+        private System.Windows.Forms.Label label22;
     }
 }

--- a/Server/MirForms/Database/MagicInfoForm.cs
+++ b/Server/MirForms/Database/MagicInfoForm.cs
@@ -29,7 +29,7 @@ namespace Server
             UpdateMagicForm();
         }
 
-        private void UpdateMagicForm()
+        private void UpdateMagicForm(byte field = 0)
         {
              _selectedMagicInfo = (MagicInfo)MagiclistBox.SelectedItem;
 
@@ -41,6 +41,7 @@ namespace Server
                  lblBookValid.Text = "Searching";
                  lblSelected.Text = "Selected Skill: none";
                  lblDamageExample.Text = "";
+                 lblDamageExplained.Text = "";
                  txtSkillIcon.Text = "0";
                  txtSkillLvl1Points.Text = "0";
                  txtSkillLvl1Req.Text = "0";
@@ -62,6 +63,7 @@ namespace Server
                  tabControl1.Enabled = true;
                  lblSelected.Text = "Selected Skill: " + _selectedMagicInfo.ToString();
                  lblDamageExample.Text = string.Format("Damage @ Skill level 0: {0:000}-{1:000}   |||   level 1: {2:000}-{3:000}   |||   level 2: {4:000}-{5:000}   |||   level 3: {6:000}-{7:000}", GetMinPower(0), GetMaxPower(0), GetMinPower(1), GetMaxPower(1), GetMinPower(2), GetMaxPower(2), GetMinPower(3), GetMaxPower(3));
+                 lblDamageExplained.Text = string.Format("Damage: {{Random(minstat-maxstat) + [<(random({0}-{1})/4) X (skill level +1)> + random<{2}-{3}>]}}  X  {{{4} + (skill level * {5})}}", _selectedMagicInfo.MPowerBase, _selectedMagicInfo.MPowerBase + _selectedMagicInfo.MPowerBonus, _selectedMagicInfo.PowerBase, _selectedMagicInfo.PowerBonus + _selectedMagicInfo.PowerBase, _selectedMagicInfo.MultiplierBase, _selectedMagicInfo.MultiplierBonus);
                  txtSkillIcon.Text = _selectedMagicInfo.Icon.ToString();
                  txtSkillLvl1Points.Text = _selectedMagicInfo.Need1.ToString();
                  txtSkillLvl1Req.Text = _selectedMagicInfo.Level1.ToString();
@@ -77,6 +79,10 @@ namespace Server
                  txtDmgBaseMax.Text = (_selectedMagicInfo.PowerBase + _selectedMagicInfo.PowerBonus).ToString();
                  txtDmgBonusMin.Text = _selectedMagicInfo.MPowerBase.ToString();
                  txtDmgBonusMax.Text = (_selectedMagicInfo.MPowerBase + _selectedMagicInfo.MPowerBonus).ToString();
+                 if (field != 1)
+                    txtDmgMultBase.Text = _selectedMagicInfo.MultiplierBase.ToString();
+                 if (field != 2)
+                 txtDmgMultBoost.Text = _selectedMagicInfo.MultiplierBonus.ToString();
                  txtRange.Text = _selectedMagicInfo.Range.ToString();
                  ItemInfo Book = Envir.GetBook((short)_selectedMagicInfo.Spell);
                  if (Book != null)
@@ -95,12 +101,12 @@ namespace Server
         private int GetMaxPower(byte level)
         {
             if (_selectedMagicInfo == null) return 0;
-            return (int)Math.Round(((_selectedMagicInfo.MPowerBase + _selectedMagicInfo.MPowerBonus) / 4F) * (level + 1) + (_selectedMagicInfo.PowerBase + _selectedMagicInfo.PowerBonus));
+            return (int)Math.Round((((_selectedMagicInfo.MPowerBase + _selectedMagicInfo.MPowerBonus) / 4F) * (level + 1) + (_selectedMagicInfo.PowerBase + _selectedMagicInfo.PowerBonus))* (_selectedMagicInfo.MultiplierBase + (level * _selectedMagicInfo.MultiplierBonus)));
         }
         private int GetMinPower(byte level)
         {
             if (_selectedMagicInfo == null) return 0;
-            return (int)Math.Round((_selectedMagicInfo.MPowerBase / 4F) * (level + 1) + _selectedMagicInfo.PowerBase);
+            return (int)Math.Round(((_selectedMagicInfo.MPowerBase / 4F) * (level + 1) + _selectedMagicInfo.PowerBase) * (_selectedMagicInfo.MultiplierBase + (level * _selectedMagicInfo.MultiplierBonus)));
         }
 
         private void InitializeComponent()
@@ -110,7 +116,6 @@ namespace Server
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
             this.lblSelected = new System.Windows.Forms.Label();
-            this.panel5 = new System.Windows.Forms.Panel();
             this.lblDamageExample = new System.Windows.Forms.Label();
             this.panel4 = new System.Windows.Forms.Panel();
             this.txtDmgBonusMax = new System.Windows.Forms.TextBox();
@@ -123,6 +128,8 @@ namespace Server
             this.label16 = new System.Windows.Forms.Label();
             this.label15 = new System.Windows.Forms.Label();
             this.panel3 = new System.Windows.Forms.Panel();
+            this.label20 = new System.Windows.Forms.Label();
+            this.txtRange = new System.Windows.Forms.TextBox();
             this.txtDelayReduction = new System.Windows.Forms.TextBox();
             this.txtDelayBase = new System.Windows.Forms.TextBox();
             this.label14 = new System.Windows.Forms.Label();
@@ -152,11 +159,13 @@ namespace Server
             this.label1 = new System.Windows.Forms.Label();
             this.lblBookValid = new System.Windows.Forms.Label();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.txtRange = new System.Windows.Forms.TextBox();
-            this.label20 = new System.Windows.Forms.Label();
+            this.txtDmgMultBoost = new System.Windows.Forms.TextBox();
+            this.txtDmgMultBase = new System.Windows.Forms.TextBox();
+            this.label21 = new System.Windows.Forms.Label();
+            this.label22 = new System.Windows.Forms.Label();
+            this.lblDamageExplained = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
-            this.panel5.SuspendLayout();
             this.panel4.SuspendLayout();
             this.panel3.SuspendLayout();
             this.panel2.SuspendLayout();
@@ -185,8 +194,9 @@ namespace Server
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.lblDamageExample);
+            this.tabPage1.Controls.Add(this.lblDamageExplained);
             this.tabPage1.Controls.Add(this.lblSelected);
-            this.tabPage1.Controls.Add(this.panel5);
             this.tabPage1.Controls.Add(this.panel4);
             this.tabPage1.Controls.Add(this.panel3);
             this.tabPage1.Controls.Add(this.panel2);
@@ -211,25 +221,22 @@ namespace Server
             this.lblSelected.TabIndex = 8;
             this.lblSelected.Text = "Selected skill: ";
             // 
-            // panel5
-            // 
-            this.panel5.Controls.Add(this.lblDamageExample);
-            this.panel5.Location = new System.Drawing.Point(14, 315);
-            this.panel5.Name = "panel5";
-            this.panel5.Size = new System.Drawing.Size(455, 28);
-            this.panel5.TabIndex = 7;
-            // 
             // lblDamageExample
             // 
             this.lblDamageExample.AutoSize = true;
-            this.lblDamageExample.Location = new System.Drawing.Point(8, 8);
+            this.lblDamageExample.Location = new System.Drawing.Point(11, 394);
             this.lblDamageExample.Name = "lblDamageExample";
-            this.lblDamageExample.Size = new System.Drawing.Size(0, 13);
+            this.lblDamageExample.Size = new System.Drawing.Size(89, 13);
             this.lblDamageExample.TabIndex = 0;
+            this.lblDamageExample.Text = "Damage example";
             // 
             // panel4
             // 
             this.panel4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panel4.Controls.Add(this.txtDmgMultBoost);
+            this.panel4.Controls.Add(this.txtDmgMultBase);
+            this.panel4.Controls.Add(this.label21);
+            this.panel4.Controls.Add(this.label22);
             this.panel4.Controls.Add(this.txtDmgBonusMax);
             this.panel4.Controls.Add(this.txtDmgBonusMin);
             this.panel4.Controls.Add(this.label18);
@@ -241,7 +248,7 @@ namespace Server
             this.panel4.Controls.Add(this.label15);
             this.panel4.Location = new System.Drawing.Point(14, 166);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(233, 143);
+            this.panel4.Size = new System.Drawing.Size(233, 191);
             this.panel4.TabIndex = 6;
             // 
             // txtDmgBonusMax
@@ -338,9 +345,26 @@ namespace Server
             this.panel3.Controls.Add(this.label12);
             this.panel3.Location = new System.Drawing.Point(253, 166);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(216, 143);
+            this.panel3.Size = new System.Drawing.Size(216, 191);
             this.panel3.TabIndex = 5;
             this.toolTip1.SetToolTip(this.panel3, "delay = <base delay> - (skill level * <decrease>)");
+            // 
+            // label20
+            // 
+            this.label20.AutoSize = true;
+            this.label20.Location = new System.Drawing.Point(12, 77);
+            this.label20.Name = "label20";
+            this.label20.Size = new System.Drawing.Size(91, 13);
+            this.label20.TabIndex = 15;
+            this.label20.Text = "Range (0 No limit)";
+            // 
+            // txtRange
+            // 
+            this.txtRange.Location = new System.Drawing.Point(121, 74);
+            this.txtRange.Name = "txtRange";
+            this.txtRange.Size = new System.Drawing.Size(79, 20);
+            this.txtRange.TabIndex = 14;
+            this.txtRange.TextChanged += new System.EventHandler(this.txtRange_TextChanged);
             // 
             // txtDelayReduction
             // 
@@ -603,22 +627,50 @@ namespace Server
             this.lblBookValid.TabIndex = 0;
             this.lblBookValid.Text = "Searching for books";
             // 
-            // txtRange
+            // txtDmgMultBoost
             // 
-            this.txtRange.Location = new System.Drawing.Point(121, 74);
-            this.txtRange.Name = "txtRange";
-            this.txtRange.Size = new System.Drawing.Size(79, 20);
-            this.txtRange.TabIndex = 14;
-            this.txtRange.TextChanged += new System.EventHandler(this.txtRange_TextChanged);
+            this.txtDmgMultBoost.Location = new System.Drawing.Point(168, 157);
+            this.txtDmgMultBoost.Name = "txtDmgMultBoost";
+            this.txtDmgMultBoost.Size = new System.Drawing.Size(46, 20);
+            this.txtDmgMultBoost.TabIndex = 14;
+            this.toolTip1.SetToolTip(this.txtDmgMultBoost, "extra multiplyer apply\'d for every skill level");
+            this.txtDmgMultBoost.TextChanged += new System.EventHandler(this.txtDmgMultBoost_TextChanged);
             // 
-            // label20
+            // txtDmgMultBase
             // 
-            this.label20.AutoSize = true;
-            this.label20.Location = new System.Drawing.Point(12, 77);
-            this.label20.Name = "label20";
-            this.label20.Size = new System.Drawing.Size(101, 13);
-            this.label20.TabIndex = 15;
-            this.label20.Text = "Range (0 No target)";
+            this.txtDmgMultBase.Location = new System.Drawing.Point(168, 131);
+            this.txtDmgMultBase.Name = "txtDmgMultBase";
+            this.txtDmgMultBase.Size = new System.Drawing.Size(46, 20);
+            this.txtDmgMultBase.TabIndex = 13;
+            this.toolTip1.SetToolTip(this.txtDmgMultBase, "multiplier apply\'d to total skill dmg");
+            this.txtDmgMultBase.TextChanged += new System.EventHandler(this.txtDmgMultBase_TextChanged);
+            // 
+            // label21
+            // 
+            this.label21.AutoSize = true;
+            this.label21.Location = new System.Drawing.Point(12, 160);
+            this.label21.Name = "label21";
+            this.label21.Size = new System.Drawing.Size(154, 13);
+            this.label21.TabIndex = 12;
+            this.label21.Text = "Damage multiplyer boost/skilllvl";
+            // 
+            // label22
+            // 
+            this.label22.AutoSize = true;
+            this.label22.Location = new System.Drawing.Point(12, 134);
+            this.label22.Name = "label22";
+            this.label22.Size = new System.Drawing.Size(119, 13);
+            this.label22.TabIndex = 11;
+            this.label22.Text = "Damage multiplyer base";
+            // 
+            // lblDamageExplained
+            // 
+            this.lblDamageExplained.AutoSize = true;
+            this.lblDamageExplained.Location = new System.Drawing.Point(11, 366);
+            this.lblDamageExplained.Name = "lblDamageExplained";
+            this.lblDamageExplained.Size = new System.Drawing.Size(50, 13);
+            this.lblDamageExplained.TabIndex = 9;
+            this.lblDamageExplained.Text = "Damage:";
             // 
             // MagicInfoForm
             // 
@@ -631,8 +683,6 @@ namespace Server
             this.tabControl1.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);
             this.tabPage1.PerformLayout();
-            this.panel5.ResumeLayout(false);
-            this.panel5.PerformLayout();
             this.panel4.ResumeLayout(false);
             this.panel4.PerformLayout();
             this.panel3.ResumeLayout(false);
@@ -678,6 +728,16 @@ namespace Server
         private bool IsValid(ref uint input)
         {
             if (!uint.TryParse(ActiveControl.Text, out input))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return false;
+            }
+            return true;
+        }
+
+        private bool IsValid(ref float input)
+        {
+            if (!float.TryParse(ActiveControl.Text, out input))
             {
                 ActiveControl.BackColor = Color.Red;
                 return false;
@@ -797,7 +857,8 @@ namespace Server
                 return;
             }
             ActiveControl.BackColor = SystemColors.Window;
-            _selectedMagicInfo.PowerBonus = temp;
+            _selectedMagicInfo.PowerBonus =  (ushort)(temp - _selectedMagicInfo.PowerBase);
+            UpdateMagicForm();
         }
 
         private void txtDmgBonusMin_TextChanged(object sender, EventArgs e)
@@ -823,7 +884,8 @@ namespace Server
             }
 
             ActiveControl.BackColor = SystemColors.Window;
-            _selectedMagicInfo.MPowerBonus = temp;
+            _selectedMagicInfo.MPowerBonus = (ushort)(temp - _selectedMagicInfo.MPowerBase);
+            UpdateMagicForm();
         }
 
         private void txtDelayBase_TextChanged(object sender, EventArgs e)
@@ -854,6 +916,29 @@ namespace Server
             
             ActiveControl.BackColor = SystemColors.Window;
             _selectedMagicInfo.Range = temp;
+        }
+
+        private void txtDmgMultBase_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            float temp = 0;
+            if (!IsValid(ref temp)) return;
+
+
+            ActiveControl.BackColor = SystemColors.Window;
+            _selectedMagicInfo.MultiplierBase = temp;
+            UpdateMagicForm(1);
+        }
+
+        private void txtDmgMultBoost_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            float temp = 0;
+            if (!IsValid(ref temp)) return;
+
+            ActiveControl.BackColor = SystemColors.Window;
+            _selectedMagicInfo.MultiplierBonus = temp;
+            UpdateMagicForm(2);
         }
     }
 }

--- a/Server/MirObjects/SpellObject.cs
+++ b/Server/MirObjects/SpellObject.cs
@@ -126,7 +126,7 @@ namespace Server.MirObjects
                     if (ob.Dead) return;
 
                     if (!ob.IsAttackTarget(Caster)) return;
-                    ob.Attacked(Caster, Value, DefenceType.None, false);
+                    ob.Attacked(Caster, Value, DefenceType.MAC, false);
                     if (!ob.Dead)
                     ob.ApplyPoison(new Poison
                         {


### PR DESCRIPTION
…@giveskill

- added 2 new fields to magic: MultiplierBase and MultiplierBonus
ALL skills use 99.9% identical calculations now (there's some minor things like crit on some war and sin and range boost on some archers)
to get a skills damage in code: damage = magic.GetDamage(attackpower(minstat,maxstat));
- made the server auto update your magicinfo table with the new multiplier settings to match original code (only a big deal if you customised your calculations

this means you can verry easely compare the damage outputs on skills > and notice problems

this nerfs some skills btw (mostly 'bugged' ones: that where doing triple maxdc or more lol)
skills are designed to have 'random' dmg not fixed max dmg.

excel file with some info : http://www.filedropper.com/skilldmglayout
put some notes on the skills that had special Info