### PR TITLE
- fixed client version for far

### DIFF
--- a/Client/Properties/AssemblyInfo.cs
+++ b/Client/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.2.3")]
-[assembly: AssemblyFileVersion("1.1.2.3")]
+[assembly: AssemblyVersion("1.1.2.4")]
+[assembly: AssemblyFileVersion("1.1.2.4")]
 [assembly: NeutralResourcesLanguage("en-GB")]
 

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -274,7 +274,7 @@ namespace Server.MirObjects
         public const int RegenDelay = 10000, EXPOwnerDelay = 5000, SearchDelay = 3000, RoamDelay = 1000, HealDelay = 600, RevivalDelay = 2000;
         public long ActionTime, MoveTime, AttackTime, RegenTime, DeadTime, SearchTime, RoamTime, HealTime;
         public long ShockTime, RageTime, HallucinationTime;
-        public bool BindingShotCenter;
+        public bool BindingShotCenter, PoisonStopRegen = true;
 
         public byte PetLevel;
         public uint PetExperience;
@@ -554,6 +554,12 @@ namespace Server.MirObjects
 
            // HealthChanged = true;
             BroadcastHealthChange();
+        }
+
+        //use this so you can have mobs take no/reduced poison damage
+        public virtual void PoisonDamage(int amount, MapObject Attacker)
+        {
+            ChangeHP(amount);
         }
         public override void Die()
         {
@@ -981,9 +987,10 @@ namespace Server.MirObjects
                             Broadcast(new S.ObjectEffect { ObjectID = ObjectID, Effect = SpellEffect.Bleeding, EffectType = 0 });
                         }
 
-                        ChangeHP(-poison.Value);
-                            
-                        RegenTime = Envir.Time + RegenDelay;
+                        //ChangeHP(-poison.Value);
+                        PoisonDamage(-poison.Value, poison.Owner);
+                        if (PoisonStopRegen)
+                            RegenTime = Envir.Time + RegenDelay;
                     }
 
                     if (poison.PType == PoisonType.DelayedExplosion)

--- a/Server/MirObjects/Monsters/ThunderElement.cs
+++ b/Server/MirObjects/Monsters/ThunderElement.cs
@@ -87,5 +87,10 @@ namespace Server.MirObjects.Monsters
             }
             return result;
         }
+
+        public override void PoisonDamage(int amount, MapObject Attacker)
+        {
+            return;
+        }
     }
 }

--- a/Server/MirObjects/Monsters/Trainer.cs
+++ b/Server/MirObjects/Monsters/Trainer.cs
@@ -9,16 +9,17 @@ namespace Server.MirObjects.Monsters
     {
         private PlayerObject _currentAttacker = null;
         private int _hitCount = 0, _totalDamage = 0;
-        private long _lastAttackTime = 0;
+        private long _lastAttackTime = 0, _StartTime = 0;
+        private bool Poisoned = false;
 
         protected override bool CanAttack { get { return false; } }
         protected override bool CanMove { get { return false; } }
-        protected override bool CanRegen { get { return false; } }
+        //protected override bool CanRegen { get { return false; } }
         protected override bool DropItem(UserItem item) { throw new NotSupportedException(); }
         protected override bool DropGold(uint gold) { throw new NotSupportedException(); }
 
         protected override void Attack() { }
-        protected override void ProcessRegen() { }
+        //protected override void ProcessRegen() { }
         protected override void ProcessRoam() { }
 
         public override bool Blocking { get { return true; } }
@@ -38,6 +39,7 @@ namespace Server.MirObjects.Monsters
 
         public override void Spawned()
         {
+            PoisonStopRegen = false;
             if (Respawn != null && Respawn.Info.Direction < 8)
                 Direction = (MirDirection)Respawn.Info.Direction;
 
@@ -65,30 +67,36 @@ namespace Server.MirObjects.Monsters
                 OutputAverage();
                 ResetStats();
             }
+
             damage += attacker.AttackBonus;
+            int armour = 0;
+            //deal with trainers defense
+            switch (type)
+            {
+                case DefenceType.AC:
+                case DefenceType.ACAgility:
+                    armour = GetAttackPower(MinAC, MaxAC);
+                    break;
+                case DefenceType.MAC:
+                case DefenceType.MACAgility:
+                    armour = GetAttackPower(MinMAC, MaxMAC);
+                    break;
+            }
+            if (armour >= damage)
+            {
+                BroadcastDamageIndicator(DamageType.Miss);
+                return 0;
+            }
+            damage -= armour;
+
+            if (_currentAttacker == null)
+                _StartTime = Envir.Time;
             _currentAttacker = attacker;
             _hitCount++;
             _totalDamage += damage;
             _lastAttackTime = Envir.Time;
-
-            switch (type)
-            {
-                case DefenceType.ACAgility:
-                    attacker.ReceiveChat(damage + " Physical Agility Damage inflicted on the trainer.", ChatType.Trainer);
-                    break;
-                case DefenceType.AC:
-                    attacker.ReceiveChat(damage + " Physical Damage inflicted on the trainer.", ChatType.Trainer);
-                    break;
-                case DefenceType.MACAgility:
-                    attacker.ReceiveChat(damage + " Magic Agility Damage inflicted on the trainer.", ChatType.Trainer);
-                    break;
-                case DefenceType.MAC:
-                    attacker.ReceiveChat(damage + " Magic Damage inflicted on the trainer.", ChatType.Trainer);
-                    break;
-                case DefenceType.Agility:
-                    attacker.ReceiveChat(damage + " Agility Damage inflicted on the trainer.", ChatType.Trainer);
-                    break;
-            }
+            
+            ReportDamage(damage, type, false);
             return 1;
         }
 
@@ -103,31 +111,36 @@ namespace Server.MirObjects.Monsters
                 ResetStats();
             }
 
+
+
+            int armour = 0;
+            //deal with trainers defense
+            switch (type)
+            {
+                case DefenceType.AC:
+                case DefenceType.ACAgility:
+                    armour = GetAttackPower(MinAC, MaxAC);
+                    break;
+                case DefenceType.MAC:
+                case DefenceType.MACAgility:
+                    armour = GetAttackPower(MinMAC, MaxMAC);
+                    break;
+            }
+            if (armour >= damage)
+            {
+                BroadcastDamageIndicator(DamageType.Miss);
+                return 0;
+            }
+            damage -= armour;
+
+            if (_currentAttacker == null)
+                _StartTime = Envir.Time;
             _currentAttacker = (PlayerObject)attacker.Master;
             _hitCount++;
             _totalDamage += damage;
             _lastAttackTime = Envir.Time;
 
-
-            switch (type)
-            {
-                case DefenceType.ACAgility:
-                    attacker.Master.ReceiveChat(damage + " AC Agility Damage inflicted on the trainer by your pet.", ChatType.Trainer);
-                    break;
-                case DefenceType.AC:
-                    attacker.Master.ReceiveChat(damage + " AC Damage inflicted on the trainer by your pet.", ChatType.Trainer);
-                    break;
-                case DefenceType.MACAgility:
-                    attacker.Master.ReceiveChat(damage + " MAC Agility Damage inflicted on the trainer by your pet.", ChatType.Trainer);
-                    break;
-                case DefenceType.MAC:
-                    attacker.Master.ReceiveChat(damage + " MAC Damage inflicted on the trainer by your pet.", ChatType.Trainer);
-                    break;
-                case DefenceType.Agility:
-                    attacker.Master.ReceiveChat(damage + " Agility Damage inflicted on the trainer by your pet.", ChatType.Trainer);
-                    break;
-            }
-
+            ReportDamage(damage, type, true);
             return 1;
         }
 
@@ -136,19 +149,105 @@ namespace Server.MirObjects.Monsters
             return 0;
         }
 
+        public override void PoisonDamage(int damage, MapObject attacker)
+        {
+            damage = damage * (-1);
+            if (attacker == null) return;
+
+            if (_currentAttacker != null && _currentAttacker != attacker)
+            {
+                OutputAverage();
+                ResetStats();
+            }
+            if (_currentAttacker == null)
+                _StartTime = Envir.Time;
+            _currentAttacker = (PlayerObject)attacker;
+            _hitCount++;
+            _totalDamage += damage;
+            _lastAttackTime = Envir.Time;
+
+            long timespend = Math.Max(1000, (Envir.Time - _StartTime));//avoid division by 0
+            if (_StartTime == 0)
+                timespend = 1000;
+            double Dps = _totalDamage / (timespend * 0.001);
+            _currentAttacker.ReceiveChat(string.Format("{1} inflicted {0} Damage, Dps: {2:#.00}.", damage, "Your poison", Dps), ChatType.Trainer);
+            Poisoned = true;
+        }
+
+        protected override void ProcessRegen()
+        {
+            if (Dead) return;
+
+            int healthRegen = 0;
+
+            if (CanRegen)
+            {
+                RegenTime = Envir.Time + RegenDelay;
+                healthRegen += (int)(MaxHP * 0.022F) + 1;
+            }
+            if (healthRegen > 0) ChangeHP(healthRegen);
+        }
+
+        public override void ChangeHP(int amount)
+        {
+            if (!Poisoned) return;
+            if (_currentAttacker == null) return;
+            _totalDamage += amount;
+            long timespend = Math.Max(1000, (Envir.Time - _StartTime));//avoid division by 0
+            if (_StartTime == 0)
+                timespend = 1000;
+            double Dps = _totalDamage / (timespend * 0.001);
+            _currentAttacker.ReceiveChat(string.Format("Your poison stopped {0} regen, Dps: {1:#.00}.", amount, Dps), ChatType.Trainer);
+        }
+
+
+        private void ReportDamage(int damage, DefenceType type, bool Pet)
+        {
+            string output = "";
+            switch (type)
+            {
+                case DefenceType.ACAgility:
+                    output = "Physical Agility";
+                    break;
+                case DefenceType.AC:
+                    output = "Physicial";
+                    break;
+                case DefenceType.MACAgility:
+                    output = "Magical Agility";
+                    break;
+                case DefenceType.MAC:
+                    output = "Magic";
+                    break;
+                case DefenceType.Agility:
+                    output = "Agility";
+                    break;
+            }
+            long timespend = Math.Max(1000,(Envir.Time - _StartTime));//avoid division by 0
+            if (_StartTime == 0)
+                timespend = 1000;
+            double Dps = _totalDamage / (timespend * 0.001);
+            _currentAttacker.ReceiveChat(string.Format("{3} inflicted {0} {1} Damage, Dps: {2:#.00}.", damage, output, Dps, Pet? "Your pet": "You"), ChatType.Trainer);
+        }
+
         private void ResetStats()
         {
             _currentAttacker = null;
             _hitCount = 0;
             _totalDamage = 0;
             _lastAttackTime = 0;
+            _StartTime = 0;
+            Poisoned = false;
+            PoisonList.Clear();
         }
 
         private void OutputAverage()
         {
             if (_currentAttacker == null) return;
-
-            _currentAttacker.ReceiveChat((_totalDamage / _hitCount) + " Average Damage inflicted on the trainer.", ChatType.Trainer);
+            long timespend = Math.Max(1000, (_lastAttackTime - _StartTime));//avoid division by 0
+            if (_StartTime == 0)
+                timespend = 1000;
+            double Dps = _totalDamage / (timespend * 0.001);
+            _currentAttacker.ReceiveChat(string.Format("{0} Average Damage inflicted on the trainer, Dps: {1:#.00}.", (int)(_totalDamage / _hitCount),Dps), ChatType.Trainer);
         }
     }
 }

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -964,7 +964,8 @@ namespace Server.MirObjects
                             Broadcast(new S.ObjectEffect { ObjectID = ObjectID, Effect = SpellEffect.Bleeding, EffectType = 0 });
                         }
 
-                        ChangeHP(-poison.Value);
+                        //ChangeHP(-poison.Value);
+                        PoisonDamage(-poison.Value, poison.Owner);
 
                         if (Dead) break;
                         RegenTime = Envir.Time + RegenDelay;
@@ -1163,6 +1164,11 @@ namespace Server.MirObjects
             // HealthChanged = true;
             Enqueue(new S.HealthChanged { HP = HP, MP = MP });
             BroadcastHealthChange();
+        }
+        //use this so you can have mobs take no/reduced poison damage
+        public void PoisonDamage(int amount, MapObject Attacker)
+        {
+            ChangeHP(amount);
         }
         public void ChangeMP(int amount)
         {


### PR DESCRIPTION
- updated trainer ai:
* it now displays the dps you're doing > so you can actualy compare skills, class's, equipment etc
* it now displays the damage poison does +  the regen the mob would be having if you didnt poison it
* it now deals with the trainers defenses

overall: with this code you can make boss 'target dummys', so you can let your users see their dps on a specific boss by giving that 'trainer' the level/hp/defense of the boss

extra's:
- elements can no longer be killed with 'green' Poison
- you can now code mob ai that is immune to poison damage / or only takes half the dmg or whatever you wanna code