### PR TITLE
added new 'if' check for npc's:

### DIFF
--- a/Server/MirObjects/NPCObject.cs
+++ b/Server/MirObjects/NPCObject.cs
@@ -1482,6 +1482,7 @@ namespace Server.MirObjects
         Random,
         Groupleader,
         GroupCount,
+        GroupCheckNearbye,
         PetLevel,
         PetCount,
         CheckCalc,
@@ -1500,6 +1501,6 @@ namespace Server.MirObjects
         AffordSiege,
         CheckPermission,
         ConquestAvailable,
-        ConquestOwner
+        ConquestOwner,
     }
 }

--- a/Server/MirObjects/NPCSegment.cs
+++ b/Server/MirObjects/NPCSegment.cs
@@ -272,6 +272,10 @@ namespace Server.MirObjects
                     CheckList.Add(new NPCChecks(CheckType.GroupCount, parts[1], parts[2]));
                     break;
 
+                case "GROUPCHECKNEARBYE":
+                    CheckList.Add(new NPCChecks(CheckType.GroupCheckNearbye));
+                    break;
+
                 case "PETCOUNT":
                     if (parts.Length < 3) return;
 
@@ -2010,6 +2014,32 @@ namespace Server.MirObjects
                         }
 
                         failed = (player.GroupMembers == null || !Compare(param[0], player.GroupMembers.Count, tempInt));
+                        break;
+                    case CheckType.GroupCheckNearbye:
+                        target = new Point(-1,-1);
+                        for (int j = 0; j < player.CurrentMap.NPCs.Count; j++)
+                        {
+                            NPCObject ob = player.CurrentMap.NPCs[j];
+                            if (ob.ObjectID != player.NPCID) continue;
+                            target = ob.CurrentLocation;
+                            break;
+                        }
+                        if (target.X == -1)
+                        {
+                            failed = true;
+                            break;
+                        }
+                        if (player.GroupMembers == null)
+                            failed = true;
+                        else
+                        {
+                            for (int j = 0; j < player.GroupMembers.Count; j++)
+                            {
+                                if (player.GroupMembers[j] == null) continue;
+                                failed |= !Functions.InRange(player.GroupMembers[j].CurrentLocation, target, 9);
+                                if (failed) break;
+                            }
+                        }
                         break;
 
                     case CheckType.PetCount:


### PR DESCRIPTION
GROUPCHECKNEARBYE
 all it does is
- check if you are in a group (safety so server dont crash :p)
- check if everyone thats in your group is near the NPCActions

so now you can make foxcave kr npc etc check if everyone is near the npc> before teleporting the group to kr