### PR TITLE
Stop ridiculously long IC names

### DIFF
--- a/Server/MirNetwork/MirConnection.cs
+++ b/Server/MirNetwork/MirConnection.cs
@@ -1569,7 +1569,8 @@ namespace Server.MirNetwork
                 {
                     if (Player.Info.IntelligentCreatures[i].PetType == petUpdate.PetType)
                     {
-                        Player.Info.IntelligentCreatures[i].CustomName = petUpdate.CustomName;
+			String newName = petUpdate.CustomName;
+                        Player.Info.IntelligentCreatures[i].CustomName = newName.Length <= 12 ? newName : Player.Info.IntelligentCreatures[i].CustomName;
                         Player.Info.IntelligentCreatures[i].SlotIndex = petUpdate.SlotIndex;
                         Player.Info.IntelligentCreatures[i].Filter = petUpdate.Filter;
                         Player.Info.IntelligentCreatures[i].petMode = petUpdate.petMode;

--- a/Server/MirNetwork/MirConnection.cs
+++ b/Server/MirNetwork/MirConnection.cs
@@ -1569,8 +1569,8 @@ namespace Server.MirNetwork
                 {
                     if (Player.Info.IntelligentCreatures[i].PetType == petUpdate.PetType)
                     {
-			String newName = petUpdate.CustomName;
-                        Player.Info.IntelligentCreatures[i].CustomName = newName.Length <= 12 ? newName : Player.Info.IntelligentCreatures[i].CustomName;
+			if (petUpdate.CustomName.length <= 12)
+                        	Player.Info.IntelligentCreatures[i].CustomName = petUpdate.CustomName
                         Player.Info.IntelligentCreatures[i].SlotIndex = petUpdate.SlotIndex;
                         Player.Info.IntelligentCreatures[i].Filter = petUpdate.Filter;
                         Player.Info.IntelligentCreatures[i].petMode = petUpdate.petMode;


### PR DESCRIPTION
Fix for this IntelligentCreature injection; I was going to add a regex to this (it doesn't / shouldn't harm the server) when injecting ASCII characters. If someone has injected ASCII characters then you can identify something fishy going on.

http://www.lomcn.org/forum/showthread.php?94317-UpdateIntelligentCreature

Ideally need to create a server side save for createRenameEnabled and enable it in the following piece of code however i'm currently on the MySQL source so it will require an additional column to be added and populated (same for flat file).

`                            case 20://Mirror
                                Enqueue(new S.IntelligentCreatureEnableRename());
                                break;
`