### PR TITLE
Public Events

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -189,6 +189,7 @@
     <Compile Include="MirScenes\Dialogs\BuffDialog.cs" />
     <Compile Include="MirScenes\Dialogs\ChatNoticeDialog.cs" />
     <Compile Include="MirScenes\Dialogs\ChatOptionDialog.cs" />
+    <Compile Include="MirScenes\Dialogs\EventDialog.cs" />
     <Compile Include="MirScenes\Dialogs\FishingDialog.cs" />
     <Compile Include="MirScenes\Dialogs\FriendDialog.cs" />
     <Compile Include="MirScenes\Dialogs\GameshopDialog.cs" />

--- a/Client/MirGraphics/MLibrary.cs
+++ b/Client/MirGraphics/MLibrary.cs
@@ -46,7 +46,9 @@ namespace Client.MirGraphics
         public static readonly MLibrary
             Items = new MLibrary(Settings.DataPath + "Items"),
             StateItems = new MLibrary(Settings.DataPath + "StateItem"),
-            FloorItems = new MLibrary(Settings.DataPath + "DNItems");
+            FloorItems = new MLibrary(Settings.DataPath + "DNItems"),
+            StateEffect = new MLibrary(Settings.DataPath + "StateEffect");
+
 
         //Deco
         public static readonly MLibrary

--- a/Client/MirObjects/ItemObject.cs
+++ b/Client/MirObjects/ItemObject.cs
@@ -7,6 +7,7 @@ using Client.MirGraphics;
 using Client.MirScenes;
 using S = ServerPackets;
 using System.Text.RegularExpressions;
+using Client.MirControls;
 
 namespace Client.MirObjects
 {
@@ -23,9 +24,21 @@ namespace Client.MirObjects
 
         public Size Size;
 
+        public MirAnimatedControl _effect;
+        public ItemGrade Grade;
 
         public ItemObject(uint objectID) : base(objectID)
         {
+            _effect = new MirAnimatedControl()
+            {
+                Animated = true,
+                AnimationCount = 25,
+                AnimationDelay = 100,
+                Index = 680,
+                Library = Libraries.StateEffect,
+                Loop = true,
+                Blending = true,
+            };
         }
 
 
@@ -44,6 +57,8 @@ namespace Client.MirObjects
             Size = BodyLibrary.GetTrueSize(DrawFrame);
 
             DrawY = CurrentLocation.Y;
+
+            Grade = info.Grade;
 
         }
         public void Load(S.ObjectGold info)
@@ -103,6 +118,41 @@ namespace Client.MirObjects
                 DisplayRectangle.X + (DisplayRectangle.Width - NameLabel.Size.Width) / 2,
                 DisplayRectangle.Y + (DisplayRectangle.Height - NameLabel.Size.Height) / 2 - 20);
             NameLabel.Draw();
+        }
+        public void DrawGradeEff()
+        {
+           if (Grade  > ItemGrade.Common)
+           {
+               switch (Grade)
+               {
+                   case ItemGrade.Rare:
+                       _effect.BackColour = Color.DeepSkyBlue;
+                       _effect.ForeColour = Color.DeepSkyBlue;
+                       break;
+                   case ItemGrade.Legendary:
+                       _effect.BackColour = Color.DarkOrange;
+                       _effect.ForeColour = Color.DarkOrange;
+                       break;
+                   case ItemGrade.Mythical:
+                       _effect.BackColour = Color.Purple;
+                       _effect.ForeColour = Color.Purple;
+                       break;
+               }
+           
+               if (Size.Width > 30)
+               {
+                   _effect.Index = 840;
+                   _effect.AnimationCount = 9;
+                   _effect.AnimationDelay = 150;
+                   Libraries.StateEffect.DrawBlend(0 + _effect.Index, new Point(DrawLocation.X - (Size.Width / 2) + 10, DrawLocation.Y + (Size.Height / 2) + 20), _effect.BackColour, true, 10F);
+               }
+               else
+               {
+                   _effect.Index = 680;
+                   _effect.AnimationCount = 25;
+                   Libraries.StateEffect.DrawBlend(0 + _effect.Index, new Point(DrawLocation.X + (Size.Width / 2), DrawLocation.Y + (Size.Height / 2)), _effect.BackColour, true, 10F);
+               }
+            }
         }
 
         public override void DrawBehindEffects(bool effectsEnabled)

--- a/Client/MirScenes/Dialogs/EventDialog.cs
+++ b/Client/MirScenes/Dialogs/EventDialog.cs
@@ -1,0 +1,131 @@
+﻿using Client.MirControls;
+using Client.MirGraphics;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Client.MirScenes.Dialogs
+{
+    public class EventDialog : MirImageControl
+    {
+        public MirLabel EventName, ObjectiveTitle, Objective, Percentage, RemainingCount, CompletionPercentage;
+        MirImageControl _progress;
+        int completedPercentage = 0;
+
+        public EventDialog()
+        {
+            Index = 14;
+            Library = Libraries.Prguse3;
+            Sort = true;
+            Location = new Point(Settings.ScreenWidth - 260, 300);
+            DrawImage = false;
+            Visible = false;
+            Movable = true;
+
+            this.BeforeDraw += (o, e) =>
+            {
+                Libraries.Prguse3.Draw(13, this.Location.X, this.Location.Y);
+                Libraries.Prguse3.Draw(14, this.Location.X, this.Location.Y);
+
+                Libraries.Prguse3.Draw(15, new Rectangle(0, 0, (int)(completedPercentage * 2), 20), new Point(this.Location.X + 10, this.Location.Y + 184), Color.White, false);
+
+
+            };
+
+            EventName = new MirLabel
+            {
+                AutoSize = true,
+                ForeColour = Color.Yellow,
+                Location = new Point(20, 40),
+                Parent = this,
+                NotControl = true,
+            };
+            ObjectiveTitle = new MirLabel
+            {
+                AutoSize = true,
+                ForeColour = Color.Yellow,
+                Location = new Point(20, 80),
+                Parent = this,
+                NotControl = true,
+                Text = "Objective",
+            };
+            Objective = new MirLabel
+            {
+                AutoSize = true,
+                ForeColour = Color.White,
+                Location = new Point(20, 100),
+                Parent = this,
+                NotControl = true,
+            };
+            RemainingCount = new MirLabel
+            {
+                AutoSize = true,
+                ForeColour = Color.White,
+                Location = new Point(20, 140),
+                Parent = this,
+                NotControl = true,
+            };
+            CompletionPercentage = new MirLabel
+            {
+                AutoSize = true,
+                ForeColour = Color.White,
+                Location = new Point(20, 160),
+                Parent = this,
+                NotControl = true,
+            };
+            //_progress = new MirImageControl()
+            //{
+            //    Index = 687,
+            //    Library = Libraries.Prguse3,
+            //    Parent = this,
+            //    Size = new Size(200,20),
+            //    DrawImage = true,
+
+            //    Location = new Point(10, 182),
+            //};
+        }
+
+        public void UpdateDialog(string eventName, string objective, int percentage, string remainingCount, int stage)
+        {
+            if (!string.IsNullOrEmpty(eventName))
+                EventName.Text = eventName;
+
+
+            var splittedRemaining = remainingCount.Split('/');
+            var aliveMonsters = splittedRemaining[0];
+            var totalMonsters = splittedRemaining[1];
+
+            RemainingCount.Text = string.Format("Monsters:{0}", aliveMonsters);
+
+            if (stage > 0)
+            {
+                if (!string.IsNullOrEmpty(objective))
+                    Objective.Text = string.Format("Stage {0}:{1}", stage, objective);
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(objective))
+                    Objective.Text = objective;
+            }
+
+            CompletionPercentage.Text = string.Format("Completed Percentage: {0}%", percentage);
+
+            //_progress.Size = new Size(percentage * 2, 182);
+            completedPercentage = percentage;
+
+        }
+        public void Show()
+        {
+            if (Visible) return;
+            Visible = true;
+        }
+
+        public void Hide()
+        {
+            Visible = false;
+        }
+    }
+}

--- a/Client/MirScenes/Dialogs/MainDialogs.cs
+++ b/Client/MirScenes/Dialogs/MainDialogs.cs
@@ -4787,6 +4787,8 @@ namespace Client.MirScenes.Dialogs
     }
     public sealed class BigMapDialog : MirControl
     {
+        public List<MirImageControl> PublicEvents = new List<MirImageControl>();
+
         public BigMapDialog()
         {
             NotControl = true;
@@ -4875,11 +4877,64 @@ namespace Client.MirScenes.Dialogs
 
                 DXManager.Sprite.Draw2D(DXManager.RadarTexture, Point.Empty, 0, new PointF((int)(x - 0.5F), (int)(y - 0.5F)), colour);
             }
+
+
+            DisposeEvents();
+            for (int i = MapControl.MapEvents.Count - 1; i >= 0; i--)
+            {
+                MapEventClientSide mapEvent = MapControl.MapEvents[i];
+
+                float x = ((mapEvent.Location.X - startPointX) * scaleX) + Location.X;
+                float y = ((mapEvent.Location.Y - startPointY) * scaleY) + Location.Y;
+
+                int imgIndex = 0;
+                switch (mapEvent.EventType)
+                {
+                    case EventType.MonsterSlay:
+                        imgIndex = 2259;
+                        break;
+                    case EventType.Invasion:
+                        imgIndex = 1811;
+                        break;
+                    case EventType.DailyBoss:
+                        imgIndex = 2091;
+                        break;
+                    case EventType.WeeklyBoss:
+                        imgIndex = 2092;
+                        break;
+                }
+
+                PublicEvents.Add(new MirImageControl()
+                {
+                    Parent = this.Parent,
+                    Library = Libraries.Items,
+                    Index = imgIndex,
+                    Location = new Point((int)(x - 10), (int)(y - 10)),
+                    NotControl = false,
+                    Visible = true,
+                    Hint = mapEvent.EventName,
+                    Blending = false,
+                    Size = new Size(10, 10)
+                });
+            }
+
         }
+        public void DisposeEvents()
+        {
+            for (int i = 0; i < PublicEvents.Count; i++)
+                PublicEvents[i].Dispose();
 
-
+            PublicEvents.Clear();
+        }
+        public void Hide()
+        {
+            DisposeEvents();
+            Visible = false;
+        }
         public void Toggle()
         {
+            DisposeEvents();
+
             Visible = !Visible;
 
             Redraw();

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -105,6 +105,7 @@ namespace Client.MirScenes
         public ItemRentalDialog ItemRentalDialog;
 
         public BuffDialog BuffsDialog;
+        public EventDialog EventDialog;
 
         //not added yet
         public KeyboardLayoutDialog KeyboardLayoutDialog;
@@ -250,6 +251,7 @@ namespace Client.MirScenes
             ItemRentalDialog = new ItemRentalDialog { Parent = this, Visible = false };
 
             BuffsDialog = new BuffDialog {Parent = this, Visible = true};
+            EventDialog = new EventDialog() { Parent = this, Visible = false };
 
             //not added yet
             KeyboardLayoutDialog = new KeyboardLayoutDialog { Parent = this, Visible = false };
@@ -461,7 +463,7 @@ namespace Client.MirScenes
                         QuestLogDialog.Hide();
                         NPCAwakeDialog.Hide();
                         RefineDialog.Hide();
-                        BigMapDialog.Visible = false;
+                        BigMapDialog.Hide();
                         if (FishingStatusDialog.bEscExit) FishingStatusDialog.Cancel();
                         MailComposeLetterDialog.Hide();
                         MailComposeParcelDialog.Hide();
@@ -1656,6 +1658,18 @@ namespace Client.MirScenes
                 case (short)ServerPacketIds.ConfirmItemRental:
                     ConfirmItemRental((S.ConfirmItemRental)p);
                     break;
+                case (short)ServerPacketIds.EnterPublicEvent:
+                    EnterPublicEvent((S.EnterOrUpdatePublicEvent)p);
+                    break;
+                case (short)ServerPacketIds.LeavePublicEvent:
+                    LeavePublicEvent((S.LeavePublicEvent)p);
+                    break;
+                case (short)ServerPacketIds.ActivateEvent:
+                    ActivateEvent((S.ActivateEvent)p);
+                    break;
+                case (short)ServerPacketIds.DeactivateEvent:
+                    DeactivateEvent((S.DeactivateEvent)p);
+                    break;
                 default:
                     base.ProcessPacket(p);
                     break;
@@ -1673,6 +1687,10 @@ namespace Client.MirScenes
                 MapControl.Dispose();
             MapControl = new MapControl { FileName = Path.Combine(Settings.MapPath, p.FileName + ".map"), Title = p.Title, MiniMap = p.MiniMap, BigMap = p.BigMap, Lights = p.Lights, Lightning = p.Lightning, Fire = p.Fire, MapDarkLight = p.MapDarkLight, Music = p.Music };
             MapControl.LoadMap();
+
+            MapControl.MapEvents.Clear();
+            MapControl.MapEvents.AddRange(p.MapEvents);
+
             InsertControl(0, MapControl);
         }
         private void UserInformation(S.UserInformation p)
@@ -3178,6 +3196,10 @@ namespace Client.MirScenes
 
             MapControl.FloorValid = false;
             MapControl.InputDelay = CMain.Time + 400;
+
+            MapControl.MapEvents.Clear();
+            MapControl.MapEvents.AddRange(p.MapEvents);
+
         }
         private void ObjectTeleportOut(S.ObjectTeleportOut p)
         {
@@ -8223,7 +8245,25 @@ namespace Client.MirScenes
             ItemRentingDialog.Reset();
             ItemRentDialog.Reset();
         }
+        public void ActivateEvent(ServerPackets.ActivateEvent p)
+        {
+            if (!MapControl.MapEvents.Any(i => i.Index == p.Event.Index))
+                MapControl.MapEvents.Add(p.Event);
+        }
 
+        public void DeactivateEvent(ServerPackets.DeactivateEvent p)
+        {
+            MapControl.MapEvents.RemoveAll(o => o.Index == p.Event.Index);
+        }
+        public void EnterPublicEvent(ServerPackets.EnterOrUpdatePublicEvent p)
+        {
+            EventDialog.UpdateDialog(p.EventName, p.Objective, p.CompletedPercentage, p.RemainingCount, p.Stage);
+            EventDialog.Show();
+        }
+        public void LeavePublicEvent(ServerPackets.LeavePublicEvent p)
+        {
+            EventDialog.Hide();
+        }
         #region Disposable
 
         protected override void Dispose(bool disposing)
@@ -8315,6 +8355,7 @@ namespace Client.MirScenes
 
         public static int ViewRangeX;
         public static int ViewRangeY;
+        public static List<MapEventClientSide> MapEvents = new List<MapEventClientSide>();
 
 
 

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -8611,6 +8611,8 @@ namespace Client.MirScenes
                     ItemObject ob = Objects[i] as ItemObject;
                     if (ob == null) continue;
 
+                    ob.DrawGradeEff();
+
                     if (!ob.MouseOver(MouseLocation))
                         ob.DrawName();
                 }

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -8257,8 +8257,13 @@ namespace Client.MirScenes
         }
         public void EnterPublicEvent(ServerPackets.EnterOrUpdatePublicEvent p)
         {
-            EventDialog.UpdateDialog(p.EventName, p.Objective, p.CompletedPercentage, p.RemainingCount, p.Stage);
+            EventDialog.UpdateDialog(p.EventName,p.ObjectiveMessage,p.Objectives, p.Stage);
             EventDialog.Show();
+
+            if (p.Objectives.All(o=> o.MonsterAliveCount == 0))
+            {
+                EventDialog.Hide();
+            }
         }
         public void LeavePublicEvent(ServerPackets.LeavePublicEvent p)
         {

--- a/Common.cs
+++ b/Common.cs
@@ -6374,6 +6374,31 @@ public class ClientRecipeInfo
     }
 
 }
+public class MonsterEventObjective
+{
+    public string MonsterName;
+    public int MonsterTotalCount;
+    public int MonsterAliveCount;
+    public MonsterEventObjective()
+    {
+
+    }
+    public MonsterEventObjective(BinaryReader reader)
+    {
+        MonsterName = reader.ReadString();
+        MonsterTotalCount = reader.ReadInt32();
+        MonsterAliveCount = reader.ReadInt32();
+    }
+    public void Save(BinaryWriter writer)
+    {
+        writer.Write(MonsterName);
+        writer.Write(MonsterTotalCount);
+        writer.Write(MonsterAliveCount);
+    }
+
+
+}
+
 public class MapEventClientSide
 {
     public int Index;

--- a/Common.cs
+++ b/Common.cs
@@ -9,6 +9,17 @@ using C = ClientPackets;
 using S = ServerPackets;
 using System.Linq;
 
+
+public enum EventType : sbyte
+{
+    None = 0,
+    MonsterSlay = 1,
+    Invasion = 2,
+    DailyBoss = 3,
+    WeeklyBoss = 4
+}
+
+
 public enum PanelType : byte
 {
     Buy = 0,
@@ -165,7 +176,8 @@ public enum DefaultNPCType : byte
     OnAcceptQuest,
     OnFinishQuest,
     Daily,
-    TalkMonster
+    TalkMonster,
+    EventReward
 }
 
 public enum IntelligentCreatureType : byte
@@ -1492,7 +1504,11 @@ public enum ServerPacketIds : short
     ItemRentalPartnerLock,
     CanConfirmItemRental,
     ConfirmItemRental,
-    NewRecipeInfo
+    NewRecipeInfo,
+    LeavePublicEvent,
+    ActivateEvent,
+    DeactivateEvent,
+    EnterPublicEvent
 }
 
 public enum ClientPacketIds : short
@@ -5211,6 +5227,14 @@ public abstract class Packet
                 return new S.ConfirmItemRental();
             case (short)ServerPacketIds.NewRecipeInfo:
                 return new S.NewRecipeInfo();
+            case (short)ServerPacketIds.LeavePublicEvent:
+                return new S.LeavePublicEvent();
+            case (short)ServerPacketIds.ActivateEvent:
+                return new S.ActivateEvent();
+            case (short)ServerPacketIds.DeactivateEvent:
+                return new S.DeactivateEvent();
+            case (short)ServerPacketIds.EnterPublicEvent:
+                return new S.EnterOrUpdatePublicEvent();
             default:
                 return null;
         }
@@ -6347,5 +6371,43 @@ public class ClientRecipeInfo
         {
             ingredient.Save(writer);
         }
+    }
+
+}
+public class MapEventClientSide
+{
+    public int Index;
+    public Point Location;
+    public int Size;
+    public bool IsActive;
+    public string EventName;
+    public EventType EventType = EventType.MonsterSlay;
+    public MapEventClientSide()
+    {
+
+    }
+    public MapEventClientSide(BinaryReader reader)
+    {
+        Index = reader.ReadInt32();
+        Size = reader.ReadInt32();
+        IsActive = reader.ReadBoolean();
+        EventName = reader.ReadString();
+
+        int x = reader.ReadInt32();
+        int y = reader.ReadInt32();
+        Location = new Point(x, y);
+
+        EventType = (EventType)reader.ReadSByte();
+    }
+    public void Save(BinaryWriter writer)
+    {
+        writer.Write(Index);
+        writer.Write(Size);
+        writer.Write(IsActive);
+        writer.Write(EventName);
+
+        writer.Write(Location.X);
+        writer.Write(Location.Y);
+        writer.Write((sbyte)EventType);
     }
 }

--- a/Server/MirDatabase/CharacterInfo.cs
+++ b/Server/MirDatabase/CharacterInfo.cs
@@ -83,6 +83,8 @@ namespace Server.MirDatabase
         public List<Poison> Poisons = new List<Poison>();
         public List<MailInfo> Mail = new List<MailInfo>();
         public List<FriendInfo> Friends = new List<FriendInfo>();
+        public List<int> DailyEventsCompleted = new List<int>();
+        public List<int> WeeklyEventsCompleted = new List<int>();
 
         //IntelligentCreature
         public List<UserIntelligentCreature> IntelligentCreatures = new List<UserIntelligentCreature>();
@@ -365,6 +367,23 @@ namespace Server.MirDatabase
                     GSpurchases.Add(reader.ReadInt32(), reader.ReadInt32());
                 }
             }
+
+            if (Envir.LoadCustomVersion >= 1)
+            {
+                count = reader.ReadInt32();
+                for (int i = 0; i < count; i++)
+                {
+                    int dailyEvent = reader.ReadInt32();
+                    DailyEventsCompleted.Add(dailyEvent);
+                }
+
+                count = reader.ReadInt32();
+                for (int i = 0; i < count; i++)
+                {
+                    int weeklyEvent = reader.ReadInt32();
+                    WeeklyEventsCompleted.Add(weeklyEvent);
+                }
+            }
         }
 
         public void Save(BinaryWriter writer)
@@ -515,6 +534,14 @@ namespace Server.MirDatabase
                 writer.Write(item.Key);
                 writer.Write(item.Value);
             }
+
+            writer.Write(DailyEventsCompleted.Count);
+            for (int i = 0; i < DailyEventsCompleted.Count; i++)
+                writer.Write(DailyEventsCompleted[i]);
+
+            writer.Write(WeeklyEventsCompleted.Count);
+            for (int i = 0; i < WeeklyEventsCompleted.Count; i++)
+                writer.Write(WeeklyEventsCompleted[i]);
         }
 
         public ListViewItem CreateListView()

--- a/Server/MirDatabase/MapEventInfo.cs
+++ b/Server/MirDatabase/MapEventInfo.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+
+namespace Server.MirDatabase
+{
+    public class PublicEventInfo
+    {
+        public string MultipleCoords = string.Empty;
+        public short EventSize = 0;
+        public string EventName = string.Empty;
+        public int CooldownInMinutes = 0;
+        public List<EventRespawn> Respawns = new List<EventRespawn>();
+        public MapInfo Info;
+        public int Index = 0;
+
+        public EventType EventType = EventType.Invasion;
+        public bool IsSafezone = false;
+
+        public PublicEventInfo()
+        {
+
+        }
+        public PublicEventInfo(BinaryReader reader)
+        {
+            Index = reader.ReadInt32();
+            MultipleCoords = reader.ReadString();
+            EventSize = reader.ReadInt16();
+            EventName = reader.ReadString();
+            CooldownInMinutes = reader.ReadInt32();
+
+            sbyte type = reader.ReadSByte();
+            EventType = (EventType)type;
+
+            IsSafezone = reader.ReadBoolean();
+
+            int count = reader.ReadInt32();
+            for (int i = 0; i < count; i++)
+                Respawns.Add(new EventRespawn(reader));
+        }
+
+        public void Save(BinaryWriter writer)
+        {
+            writer.Write(Index);
+            writer.Write(MultipleCoords);
+            writer.Write(EventSize);
+            writer.Write(EventName);
+            writer.Write(CooldownInMinutes);
+            writer.Write((sbyte)EventType);
+            writer.Write(IsSafezone);
+
+            writer.Write(Respawns.Count);
+            for (int i = 0; i < Respawns.Count; i++)
+                Respawns[i].Save(writer);
+        }
+        public override string ToString()
+        {
+            return string.Format("[{0}] {1}", Index, EventName);
+        }
+
+    }
+
+    public class EventRespawn
+    {
+        public string MonsterName;
+        public ushort MonsterCount;
+        public ushort Order;
+        public ushort SpreadX;
+        public ushort SpreadY;
+        public bool IsObjective = false;
+        public EventRespawn()
+        {
+            MonsterName = string.Empty;
+            MonsterCount = 0;
+            Order = 0;
+            SpreadX = 0;
+            SpreadY = 0;
+            IsObjective = false;
+        }
+        public EventRespawn(BinaryReader reader)
+        {
+            MonsterName = reader.ReadString();
+            MonsterCount = reader.ReadUInt16();
+            Order = reader.ReadUInt16();
+            SpreadX = reader.ReadUInt16();
+            SpreadY = reader.ReadUInt16();
+            IsObjective = reader.ReadBoolean();
+        }
+        public void Save(BinaryWriter writer)
+        {
+            writer.Write(MonsterName);
+            writer.Write(MonsterCount);
+            writer.Write(Order);
+            writer.Write(SpreadX);
+            writer.Write(SpreadY);
+            writer.Write(IsObjective);
+        }
+        public override string ToString()
+        {
+            return string.Format("Monster: {0} - Count: {1} ", MonsterName, MonsterCount.ToString());
+        }
+    }
+}

--- a/Server/MirDatabase/MapEventInfo.cs
+++ b/Server/MirDatabase/MapEventInfo.cs
@@ -15,6 +15,8 @@ namespace Server.MirDatabase
         public MapInfo Info;
         public int Index = 0;
 
+        public string ObjectiveMessage = string.Empty;
+
         public EventType EventType = EventType.Invasion;
         public bool IsSafezone = false;
 
@@ -38,6 +40,9 @@ namespace Server.MirDatabase
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)
                 Respawns.Add(new EventRespawn(reader));
+
+            if (MirEnvir.Envir.LoadCustomVersion >= 2)
+                ObjectiveMessage = reader.ReadString();
         }
 
         public void Save(BinaryWriter writer)
@@ -53,6 +58,8 @@ namespace Server.MirDatabase
             writer.Write(Respawns.Count);
             for (int i = 0; i < Respawns.Count; i++)
                 Respawns[i].Save(writer);
+
+            writer.Write(ObjectiveMessage);
         }
         public override string ToString()
         {

--- a/Server/MirDatabase/MapInfo.cs
+++ b/Server/MirDatabase/MapInfo.cs
@@ -27,6 +27,7 @@ namespace Server.MirDatabase
         public List<NPCInfo> NPCs = new List<NPCInfo>();
         public List<MineZone> MineZones = new List<MineZone>();
         public List<Point> ActiveCoords = new List<Point>();
+        public List<PublicEventInfo> PublicEvents = new List<PublicEventInfo>();
 
         public InstanceInfo Instance;
 
@@ -101,7 +102,14 @@ namespace Server.MirDatabase
             NoFight = reader.ReadBoolean();
 
             if (Envir.LoadVersion < 53) return;
-                Music = reader.ReadUInt16(); 
+                Music = reader.ReadUInt16();
+
+            if (Envir.LoadCustomVersion >= 1)
+            {
+                count = reader.ReadInt32();
+                for (int i = 0; i < count; i++)
+                    PublicEvents.Add(new PublicEventInfo(reader));
+            }
 
         }
 
@@ -156,7 +164,9 @@ namespace Server.MirDatabase
 
             writer.Write(Music);
 
-            
+            writer.Write(PublicEvents.Count);
+            for (int i = 0; i < PublicEvents.Count; i++)
+                PublicEvents[i].Save(writer);
         }
 
 
@@ -184,7 +194,10 @@ namespace Server.MirDatabase
                 if (SafeZones[i].StartPoint)
                     SMain.Envir.StartPoints.Add(SafeZones[i]);
         }
-
+        public void CreatePublicEvent()
+        {
+            PublicEvents.Add(new PublicEventInfo { Info = this, Index = ++SMain.EditEnvir.MapEventIndex });
+        }
         public void CreateInstance()
         {
             if (Instance.MapList.Count == 0) return;

--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -12,6 +12,7 @@ using Server.MirDatabase;
 using Server.MirNetwork;
 using Server.MirObjects;
 using S = ServerPackets;
+using System.Threading.Tasks;
 
 namespace Server.MirEnvir
 {
@@ -56,10 +57,12 @@ namespace Server.MirEnvir
         public static object LoadLock = new object();
 
         public const int Version = 77;
-        public const int CustomVersion = 0;
+        public const int CustomVersion = 1;
         public const string DatabasePath = @".\Server.MirDB";
         public const string AccountPath = @".\Server.MirADB";
         public const string BackUpPath = @".\Back Up\";
+        public const string RunTimeValuesDBPath = @".\Server.MirRTVDB";
+
         public bool ResetGS = false;
 
         private static readonly Regex AccountIDReg, PasswordReg, EMailReg, CharacterReg;
@@ -107,7 +110,7 @@ namespace Server.MirEnvir
         
 
         //Server DB
-        public int MapIndex, ItemIndex, MonsterIndex, NPCIndex, QuestIndex, GameshopIndex, ConquestIndex, RespawnIndex;
+        public int MapIndex, ItemIndex, MonsterIndex, NPCIndex, QuestIndex, GameshopIndex, ConquestIndex, RespawnIndex, MapEventIndex;
         public List<MapInfo> MapInfoList = new List<MapInfo>();
         public List<ItemInfo> ItemInfoList = new List<ItemInfo>();
         public List<MonsterInfo> MonsterInfoList = new List<MonsterInfo>();
@@ -141,7 +144,8 @@ namespace Server.MirEnvir
 
         public List<ConquestInfo> ConquestInfos = new List<ConquestInfo>();
         public List<ConquestObject> Conquests = new List<ConquestObject>();
-        
+        public int CurrentWeekOfTheYear = 0;
+        public int CurrentDayOfTheYear = 0;
 
 
         //multithread vars
@@ -202,7 +206,7 @@ namespace Server.MirEnvir
         public static long LastRunTime = 0;
         public int MonsterCount;
 
-        private long warTime, mailTime, guildTime, conquestTime, rentalItemsTime;
+        private long warTime, mailTime, guildTime, conquestTime, rentalItemsTime, runtimeValuesTime;
         private int DailyTime = DateTime.Now.Day;
 
         private bool MagicExists(Spell spell)
@@ -636,6 +640,7 @@ namespace Server.MirEnvir
                             SaveGuilds();
                             SaveGoods();
                             SaveConquests();
+                            SaveRunTimeValues();
                         }
 
                         if (Time >= userTime)
@@ -687,7 +692,7 @@ namespace Server.MirEnvir
                 SaveAccounts();
                 SaveGuilds(true);
                 SaveConquests(true);
-
+                SaveRunTimeValues();
             }
             catch (Exception ex)
             {
@@ -863,6 +868,12 @@ namespace Server.MirEnvir
                 ProcessRentedItems();
             }
 
+            if (Time >= runtimeValuesTime)
+            {
+                runtimeValuesTime = Time + (Settings.Hour);
+                ProcessRunTimeValues();
+            }
+
         }
 
         public void Broadcast(Packet p)
@@ -925,6 +936,17 @@ namespace Server.MirEnvir
                     ConquestInfos[i].Save(writer);
 
                 RespawnTick.Save(writer);
+
+                writer.Write(MapEventIndex);
+            }
+        }
+        public void SaveRunTimeValues()
+        {
+            using (FileStream stream = File.Create(RunTimeValuesDBPath))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write(CurrentWeekOfTheYear);
+                writer.Write(CurrentDayOfTheYear);
             }
         }
         public void SaveAccounts()
@@ -1297,13 +1319,28 @@ namespace Server.MirEnvir
                     if (LoadVersion > 67)
                         RespawnTick = new RespawnTimer(reader);
 
+                    if (LoadCustomVersion >= 1)
+                        MapEventIndex = reader.ReadInt32();
+
                 }
 
                 Settings.LinkGuildCreationItems(ItemInfoList);
             }
 
         }
+        public void LoadRunTimeValues()
+        {
+            if (!File.Exists(RunTimeValuesDBPath))
+                SaveRunTimeValues();
 
+            using (FileStream stream = File.OpenRead(RunTimeValuesDBPath))
+            using (BinaryReader reader = new BinaryReader(stream))
+            {
+                CurrentWeekOfTheYear = reader.ReadInt32();
+                CurrentDayOfTheYear = reader.ReadInt32();
+            }
+
+        }
         public void LoadAccounts()
         {
             //reset ranking
@@ -1921,6 +1958,8 @@ namespace Server.MirEnvir
             LoadGuilds();
 
             LoadConquests();
+
+            LoadRunTimeValues();
 
             _listener = new TcpListener(IPAddress.Parse(Settings.IPAddress), Settings.Port);
             _listener.Start();
@@ -3015,7 +3054,58 @@ namespace Server.MirEnvir
                 info.Player.GetCompletedQuests();
             }       
         }
+        public void ProcessRunTimeValues()
+        {
+            var cal = System.Globalization.DateTimeFormatInfo.CurrentInfo.Calendar;
 
+            bool saveDB = false;
+            bool clearDailyValues = false;
+            bool clearWeeklyValues = false;
+
+            //If there is a mismatch with current week and saved week in the database we will clear values
+            int weekYear = cal.GetWeekOfYear(DateTime.Now, System.Globalization.CalendarWeekRule.FirstDay, DayOfWeek.Monday);
+            if (weekYear != CurrentWeekOfTheYear)
+            {
+                clearWeeklyValues = true;
+                CurrentWeekOfTheYear = weekYear;
+            }
+
+            int dayOfYear = cal.GetDayOfYear(DateTime.Now);
+            if (dayOfYear != CurrentDayOfTheYear)
+            {
+                clearDailyValues = true;
+                CurrentDayOfTheYear = dayOfYear;
+            }
+
+            if (clearDailyValues || clearWeeklyValues)
+            {
+                CleanCharacterRunTimeValues(clearWeeklyValues, clearDailyValues);
+                saveDB = true;
+            }
+
+            if (saveDB)
+                SaveRunTimeValues();
+        }
+        public void CleanCharacterRunTimeValues(bool clearWeekly,bool clearDaily)
+        {
+            if (clearWeekly)
+                SMain.EnqueueDebugging(string.Format("{0}: Removing Players Weekly Completed Events", DateTime.Now));
+
+            if (clearDaily)
+                SMain.EnqueueDebugging(string.Format("{0}: Removing Players Daily Completed Events", DateTime.Now));
+
+            Task.Run(() =>
+            {
+                foreach (var charInfo in CharacterList)
+                {
+                    if (clearDaily)
+                        charInfo.DailyEventsCompleted.Clear();
+
+                    if (clearWeekly)
+                        charInfo.WeeklyEventsCompleted.Clear();
+                }
+            });
+        }
         public GuildBuffInfo FindGuildBuffInfo(int Id)
         {
             for (int i = 0; i < Settings.Guild_BuffList.Count; i++)

--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -57,7 +57,7 @@ namespace Server.MirEnvir
         public static object LoadLock = new object();
 
         public const int Version = 77;
-        public const int CustomVersion = 1;
+        public const int CustomVersion = 2;
         public const string DatabasePath = @".\Server.MirDB";
         public const string AccountPath = @".\Server.MirADB";
         public const string BackUpPath = @".\Back Up\";

--- a/Server/MirEnvir/Map.cs
+++ b/Server/MirEnvir/Map.cs
@@ -36,11 +36,16 @@ namespace Server.MirEnvir
 
         public List<ConquestObject> Conquest = new List<ConquestObject>();
         public ConquestObject tempConquest;
+        public List<PublicEvent> Events = new List<PublicEvent>();
 
         public Map(MapInfo info)
         {
             Info = info;
             Thread = Envir.Random.Next(Settings.ThreadLimit);
+
+            foreach (var publicEventInfo in info.PublicEvents)
+                Events.Add(new PublicEvent(publicEventInfo, this));
+
         }
 
         public Door AddDoor(byte DoorIndex, Point location)
@@ -723,6 +728,7 @@ namespace Server.MirEnvir
                     InactiveCount = 0;
                 }
             }
+            Events.ForEach(e => e.Process());
 
         }
 
@@ -2201,7 +2207,19 @@ namespace Server.MirEnvir
             }
             return null;
         }
+        public PublicEvent GetPublicEvent(Point location)
+        {
+            for (int i = 0; i < Events.Count; i++)
+            {
+                PublicEvent publicEvent = Events[i];
+                if (!publicEvent.IsActive)
+                    continue;
 
+                if (Functions.InRange(publicEvent.CurrentLocation, location, publicEvent.Info.EventSize))
+                    return publicEvent;
+            }
+            return null;
+        }
         //public ConquestObject GetInnerConquest(Map map, Point location)
         //{
         //    for (int i = 0; i < Conquest.Count; i++)
@@ -2299,6 +2317,8 @@ namespace Server.MirEnvir
         public byte ErrorCount = 0;
 
         public List<RouteInfo> Route;
+        public bool IsEventObjective = false;
+        public PublicEvent Event;
 
         public MapRespawn(RespawnInfo info)
         {

--- a/Server/MirEnvir/MapEvent.cs
+++ b/Server/MirEnvir/MapEvent.cs
@@ -316,10 +316,7 @@ namespace Server.MirEnvir
 
             #region RemoveBoundaries
             foreach (var spellObj in Zone)
-            {
                 spellObj.Despawn();
-                Map.RemoveObject(spellObj);
-            }
             #endregion
         }
         public void AwardPlayers()

--- a/Server/MirEnvir/MapEvent.cs
+++ b/Server/MirEnvir/MapEvent.cs
@@ -317,8 +317,8 @@ namespace Server.MirEnvir
             #region RemoveBoundaries
             foreach (var spellObj in Zone)
             {
-                spellObj.Despawn();
                 Map.RemoveObject(spellObj);
+                spellObj.Despawn();
             }
             #endregion
         }

--- a/Server/MirEnvir/MapEvent.cs
+++ b/Server/MirEnvir/MapEvent.cs
@@ -1,0 +1,503 @@
+﻿using Server.MirDatabase;
+using Server.MirObjects;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using S = ServerPackets;
+
+namespace Server.MirEnvir
+{
+    public class PublicEvent
+    {
+        private static Envir Envir
+        {
+            get { return SMain.Envir; }
+        }
+        public PublicEventInfo Info;
+        public Map Map;
+        public List<Point> Locations = new List<Point>();
+        public Point CurrentLocation;
+        public List<MapRespawn> MapRespawns = new List<MapRespawn>();
+        public DateTime LastRunTime = DateTime.MinValue;
+        public NPCObject DefaultNPC;
+        public List<SpellObject> Zone = new List<SpellObject>();
+        public List<PlayerObject> Contributers = new List<PlayerObject>();
+        public int Stage = 0;
+
+        public List<PlayerObject> Players
+        {
+            get
+            {
+                List<PlayerObject> players = new List<PlayerObject>();
+                for (int d = 0; d <= Info.EventSize; d++)
+                {
+                    for (int y = CurrentLocation.Y - d; y <= CurrentLocation.Y + d; y++)
+                    {
+                        if (y < 0) continue;
+                        if (y >= Map.Height) break;
+                        for (int x = CurrentLocation.X - d; x <= CurrentLocation.X + d; x += Math.Abs(y - CurrentLocation.Y) == d ? 1 : d * 2)
+                        {
+                            if (x < 0) continue;
+                            if (x >= Map.Width) break;
+
+                            Cell cell = Map.GetCell(x, y);
+                            if (!cell.Valid || cell.Objects == null) continue;
+
+                            for (int i = 0; i < cell.Objects.Count; i++)
+                            {
+                                MapObject ob = cell.Objects[i];
+                                switch (ob.Race)
+                                {
+                                    case ObjectType.Player:
+                                        PlayerObject p = (PlayerObject)ob;
+                                        players.Add(p);
+                                        continue;
+                                    default:
+                                        continue;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return players;
+            }
+
+        }
+        private bool _isActive;
+        public bool IsActive
+        {
+            get { return _isActive; }
+            set
+            {
+                //If event alrdy active and we're disabling it
+                if (_isActive && !value)
+                    DeactivateEvent();
+
+                if (value)
+                    ActivateEvent();
+
+                _isActive = value;
+            }
+        }
+        public PublicEvent(PublicEventInfo info, Map map)
+        {
+            Info = info;
+            Map = map;
+
+            var splittedCoords = info.MultipleCoords.Split(',');
+            foreach (var coord in splittedCoords)
+            {
+                var secondSplit = coord.Split(':');
+
+                int x = 0; int y = 0;
+                if (!int.TryParse(secondSplit[0], out x))
+                    return;
+                if (!int.TryParse(secondSplit[1], out y))
+                    return;
+
+                Locations.Add(new Point(x, y));
+
+
+                string fileName = string.Format("{0}-Event-{1}.txt", map.Info.FileName, info.Index);
+                string directoryFileName = Path.Combine(Settings.EventsPath, fileName);
+
+                if (!Directory.Exists(Settings.EventsPath))
+                    Directory.CreateDirectory(Settings.EventsPath);
+
+                if (!File.Exists(directoryFileName))
+                {
+                    FileStream NewFile = File.Create(directoryFileName);
+                    NewFile.Close();
+                }
+
+                DefaultNPC = new NPCObject(new NPCInfo() { Name = "DefaultNPC", FileName = fileName, IsDefault = true });
+
+            }
+        }
+        public void ActivateEvent()
+        {
+            Point randomLocation = Locations[Envir.Random.Next(Locations.Count)];
+            CurrentLocation = randomLocation;
+            SMain.EnqueueDebugging(string.Format("{0} Activating Event:{1}", Map.Info.FileName, Info.EventName));
+            switch (Info.EventType)
+            {
+                case EventType.Invasion:
+                    Stage = 1;
+                    SpawnInvasionMonsters(1);
+                    break;
+                default:
+                    SpawnMonsters();
+                    break;
+            }
+
+            MapEventClientSide eventNotification = new MapEventClientSide()
+            {
+                EventName = Info.EventName,
+                EventType = Info.EventType,
+                Index = Info.Index,
+                IsActive = true,
+                Size = Info.EventSize,
+                Location = CurrentLocation
+            };
+
+            foreach (var player in Map.Players)
+                player.Enqueue(new S.ActivateEvent() { Event = eventNotification });
+
+            #region Boundaries
+            for (int y = CurrentLocation.Y - Info.EventSize; y <= CurrentLocation.Y + Info.EventSize; y++)
+            {
+                if (y < 0) continue;
+                if (y >= Map.Height) break;
+                for (int x = CurrentLocation.X - Info.EventSize; x <= CurrentLocation.X + Info.EventSize; x += Math.Abs(y - CurrentLocation.Y) == Info.EventSize ? 1 : Info.EventSize * 2)
+                {
+                    if (x < 0) continue;
+                    if (x >= Map.Width) break;
+                    if (!Map.Cells[x, y].Valid) continue;
+
+                    SpellObject spell = new SpellObject
+                    {
+                        ExpireTime = long.MaxValue,
+                        Spell = this.Info.IsSafezone ? Spell.TrapHexagon : Spell.FireWall,
+                        TickSpeed = int.MaxValue,
+                        CurrentLocation = new Point(x, y),
+                        CurrentMap = Map,
+                        Decoration = true
+                    };
+
+                    Map.Cells[x, y].Add(spell);
+                    Zone.Add(spell);
+                    spell.Spawned();
+                }
+            }
+            #endregion
+        }
+        private void SpawnInvasionMonsters(int order)
+        {
+            var respawns = Info.Respawns.Where(o => o.Order == order).ToList();
+            if (respawns == null || respawns.Count == 0)
+            {
+                SMain.EnqueueDebugging(string.Format("De Activating Invasion Event:{0} Stage:{1}", Info.EventName, Stage));
+                IsActive = false;
+            }
+
+            SpawnMonstersForInvasion(respawns);
+
+
+            var p = new S.EnterOrUpdatePublicEvent { };
+            int total = respawns.Where(r => r.IsObjective).Select(o => o.MonsterCount).Sum(o => o);
+            int alive = total;
+
+            var monsterNames = respawns.Select(mr => mr.MonsterName).Distinct().ToList();
+            var obj = (string.Format("{0}", string.Join(",", monsterNames)));
+
+            p.RemainingCount = string.Format("{0}/{1}", alive, total);
+            p.Stage = Stage;
+            p.Objective = obj;
+
+            foreach (var player in Players)
+                player.Enqueue(p);
+        }
+        private void SpawnMonstersForInvasion(List<EventRespawn> respawns)
+        {
+            var topLeftLocation = new Point(CurrentLocation.X - Info.EventSize, CurrentLocation.Y - Info.EventSize);
+
+            foreach (var eventRespawn in respawns)
+            {
+                var monster = Envir.GetMonsterInfo(eventRespawn.MonsterName);
+                if (monster == null)
+                {
+                    SMain.EnqueueDebugging(string.Format("{0} Event:{1} FAILED COULDN'T FIND MONSTER {2}", Map.Info.FileName, Info.EventName, eventRespawn.MonsterName));
+                    continue;
+                }
+
+                var respawnInfo = new RespawnInfo()
+                {
+                    Spread = eventRespawn.MonsterCount,
+                    Count = eventRespawn.MonsterCount,
+                    MonsterIndex = monster.Index,
+                    Delay = ushort.MaxValue
+                };
+
+                if (eventRespawn.SpreadY == 0 && eventRespawn.SpreadX == 0)
+                    respawnInfo.Location = CurrentLocation;
+                else
+                    respawnInfo.Location = new Point(topLeftLocation.X + eventRespawn.SpreadX * 2, topLeftLocation.Y + eventRespawn.SpreadY * 2);
+
+                MapRespawn mapRespawn = new MapRespawn(respawnInfo);
+
+                RouteInfo route = new RouteInfo()
+                {
+                    Location = respawnInfo.Location,
+                    Delay = 1000,
+                };
+                mapRespawn.Route.Add(route);
+
+                mapRespawn.Map = Map;
+                mapRespawn.IsEventObjective = eventRespawn.IsObjective;
+                mapRespawn.Event = this;
+                MapRespawns.Add(mapRespawn);
+            }
+
+            Map.Respawns.AddRange(MapRespawns);
+        }
+
+        private void SpawnMonsters()
+        {
+            var topLeftLocation = new Point(CurrentLocation.X - Info.EventSize, CurrentLocation.Y - Info.EventSize);
+
+            foreach (var eventRespawn in Info.Respawns)
+            {
+
+                var respawnInfo = new RespawnInfo();
+
+                var monster = Envir.GetMonsterInfo(eventRespawn.MonsterName);
+                if (monster == null)
+                {
+                    SMain.EnqueueDebugging(string.Format("{0} Activating Event:{1} FAILED COULDN'T FIND MONSTER {2}", Map.Info.FileName, Info.EventName, eventRespawn.MonsterName));
+                    return;
+                }
+                respawnInfo.Spread = eventRespawn.MonsterCount;
+                respawnInfo.Count = eventRespawn.MonsterCount;
+                respawnInfo.MonsterIndex = monster.Index;
+                respawnInfo.Delay = 10000;
+                respawnInfo.SaveRespawnTime = false;
+                respawnInfo.RespawnIndex = 0;
+                respawnInfo.RespawnTicks = 0;
+
+
+                if (eventRespawn.SpreadY == 0 && eventRespawn.SpreadX == 0 && eventRespawn.MonsterCount == 1)
+                    respawnInfo.Location = CurrentLocation;
+                else
+                    respawnInfo.Location = new Point(topLeftLocation.X + eventRespawn.SpreadX * 2, topLeftLocation.Y + eventRespawn.SpreadY * 2);
+
+                MapRespawn mapRespawn = new MapRespawn(respawnInfo);
+
+                RouteInfo route = new RouteInfo();
+                route.Location = respawnInfo.Location;
+                route.Delay = 1000;
+                mapRespawn.Route.Add(route);
+
+                mapRespawn.Map = Map;
+                mapRespawn.IsEventObjective = eventRespawn.IsObjective;
+                mapRespawn.Event = this;
+                MapRespawns.Add(mapRespawn);
+            }
+
+            Map.Respawns.AddRange(MapRespawns);
+        }
+
+        public void DeactivateEvent()
+        {
+            LastRunTime = DateTime.Now;
+
+            foreach (var mapRespawn in MapRespawns)
+                Map.Respawns.Remove(mapRespawn);
+
+            MapRespawns.Clear();
+
+            Stage = 0;
+            AwardPlayers();
+
+            MapEventClientSide eventNotification = new MapEventClientSide()
+            {
+                EventName = Info.EventName,
+                EventType = Info.EventType,
+                Index = Info.Index,
+                IsActive = false,
+                Size = Info.EventSize,
+                Location = CurrentLocation
+            };
+
+            foreach (var player in Map.Players)
+                player.Enqueue(new S.DeactivateEvent() { Event = eventNotification });
+
+            #region RemoveBoundaries
+            foreach (var spellObj in Zone)
+            {
+                spellObj.Despawn();
+                Map.RemoveObject(spellObj);
+            }
+            #endregion
+        }
+        public void AwardPlayers()
+        {
+            List<PlayerObject> insidePlayers = new List<PlayerObject>();
+            insidePlayers.AddRange(Players);
+
+            foreach (var contributer in Contributers)
+            {
+                if (!insidePlayers.Contains(contributer) || contributer.Info == null)
+                    continue;
+
+                switch (Info.EventType)
+                {
+                    case EventType.DailyBoss:
+                        if (contributer.CanGainDailyAward(Info.Index))
+                            contributer.Info.DailyEventsCompleted.Add(Info.Index);
+                        else
+                            continue;
+                        break;
+                    case EventType.WeeklyBoss:
+                        if (contributer.CanGainWeeklyAward(Info.Index))
+                            contributer.Info.WeeklyEventsCompleted.Add(Info.Index);
+                        else
+                            continue;
+                        break;
+                }
+                CallDefaultNPC(DefaultNPCType.EventReward, contributer);
+            }
+            Contributers.Clear();
+        }
+
+        public void EventMonsterDied(List<PlayerObject> monsterContributers)
+        {
+            if (!IsActive)
+                return;
+
+            for (int i = 0; i < monsterContributers.Count; i++)
+            {
+                var monContributor = monsterContributers[i];
+                if (!Contributers.Contains(monContributor))
+                    Contributers.Add(monContributor);
+            }
+
+            switch (Info.EventType)
+            {
+                case EventType.Invasion:
+                    var invasionRespawns = MapRespawns.Where(o => o.IsEventObjective);
+
+                    if (invasionRespawns.All(o => o.Count == 0))
+                    {
+                        Stage++;
+                        SpawnInvasionMonsters(Stage);
+                    }
+                    else
+                    {
+                        var monsterNames = MapRespawns.Select(mr => mr.Monster.Name).Distinct().ToList();
+                        var obj = (string.Format("{0}", string.Join(",", monsterNames)));
+
+                        int total = invasionRespawns.Select(o => o.Info.Count).Sum(o => o);
+                        int alive = invasionRespawns.Select(o => o.Count).Sum(o => o);
+                        var dead = total - alive;
+
+                        var remainingCount = string.Format("{0}/{1}", alive, total);
+                        var completedPerc = (int)(((decimal)dead / total) * 100);
+                        var p = new S.EnterOrUpdatePublicEvent(Info.EventName, obj, remainingCount, completedPerc, Stage);
+
+                        foreach (var player in Players)
+                            player.Enqueue(p);
+                    }
+                    break;
+                default:
+                    var objectiveRespawns = MapRespawns.Where(o => o.IsEventObjective);
+
+                    int totalMonstersAsObj = objectiveRespawns.Select(o => o.Info.Count).Sum(o => o);
+                    int aliveMonstersCount = objectiveRespawns.Select(o => o.Count).Sum(o => o);
+                    var deadMonsters = totalMonstersAsObj - aliveMonstersCount;
+
+                    var remainCount = string.Format("{0}/{1}", aliveMonstersCount, totalMonstersAsObj);
+                    var percent = (int)(((decimal)deadMonsters / totalMonstersAsObj) * 100);
+
+                    var packet = new S.EnterOrUpdatePublicEvent(Info.EventName, string.Empty, remainCount, percent, Stage);
+
+                    foreach (var player in Players)
+                        player.Enqueue(packet);
+
+
+                    if (objectiveRespawns.All(o => o.Count == 0))
+                    {
+                        SMain.EnqueueDebugging(string.Format("De Activating Event:{0}", Info.EventName));
+                        IsActive = false;
+                    }
+                    break;
+            }
+        }
+        public void Process()
+        {
+            //First Run
+            if (LastRunTime == DateTime.MinValue)
+            {
+                IsActive = true;
+                LastRunTime = DateTime.Now;
+                return;
+            }
+
+            //Process Logic
+            if (!IsActive)
+            { 
+                if ((DateTime.Now - LastRunTime).TotalMinutes > Info.CooldownInMinutes)
+                    IsActive = true;
+            }
+
+        }
+        public void CallDefaultNPC(DefaultNPCType type, PlayerObject player, params object[] value)
+        {
+            string key = string.Empty;
+
+            switch (type)
+            {
+                case DefaultNPCType.Login:
+                    key = "Login";
+                    break;
+                case DefaultNPCType.UseItem:
+                    if (value.Length < 1) return;
+                    key = string.Format("UseItem({0})", value[0]);
+                    break;
+                case DefaultNPCType.Trigger:
+                    if (value.Length < 1) return;
+                    key = string.Format("Trigger({0})", value[0]);
+                    break;
+                case DefaultNPCType.MapCoord:
+                    if (value.Length < 3) return;
+                    key = string.Format("MapCoord({0},{1},{2})", value[0], value[1], value[2]);
+                    break;
+                case DefaultNPCType.MapEnter:
+                    if (value.Length < 1) return;
+                    key = string.Format("MapEnter({0})", value[0]);
+                    break;
+                case DefaultNPCType.Die:
+                    key = "Die";
+                    break;
+                case DefaultNPCType.LevelUp:
+                    key = "LevelUp";
+                    break;
+                case DefaultNPCType.CustomCommand:
+                    if (value.Length < 1) return;
+                    key = string.Format("CustomCommand({0})", value[0]);
+                    break;
+                case DefaultNPCType.OnAcceptQuest:
+                    if (value.Length < 1) return;
+                    key = string.Format("OnAcceptQuest({0})", value[0]);
+                    break;
+                case DefaultNPCType.OnFinishQuest:
+                    if (value.Length < 1) return;
+                    key = string.Format("OnFinishQuest({0})", value[0]);
+                    break;
+                case DefaultNPCType.Daily:
+                    key = "Daily";
+                    player.Info.NewDay = false;
+                    break;
+                case DefaultNPCType.TalkMonster:
+                    if (value.Length < 1) return;
+                    key = string.Format("TalkMonster({0})", value[0]);
+                    break;
+                case DefaultNPCType.EventReward:
+                    key = "EventReward";
+                    break;
+            }
+            key = string.Format("[@_{0}]", key);
+
+            if (player == null)
+                return;
+
+            DelayedAction action = new DelayedAction(DelayedType.NPC, SMain.Envir.Time + 1, DefaultNPC.ObjectID, key);
+            player.ActionList.Add(action);
+
+            player.Enqueue(new S.NPCUpdate { NPCID = DefaultNPC.ObjectID });
+        }
+    }
+
+}

--- a/Server/MirEnvir/MapEvent.cs
+++ b/Server/MirEnvir/MapEvent.cs
@@ -316,7 +316,10 @@ namespace Server.MirEnvir
 
             #region RemoveBoundaries
             foreach (var spellObj in Zone)
+            {
                 spellObj.Despawn();
+                Map.RemoveObject(spellObj);
+            }
             #endregion
         }
         public void AwardPlayers()

--- a/Server/MirEnvir/MapEvent.cs
+++ b/Server/MirEnvir/MapEvent.cs
@@ -320,6 +320,7 @@ namespace Server.MirEnvir
                 Map.RemoveObject(spellObj);
                 spellObj.Despawn();
             }
+            Zone.Clear();
             #endregion
         }
         public void AwardPlayers()

--- a/Server/MirForms/Database/MapInfoForm.Designer.cs
+++ b/Server/MirForms/Database/MapInfoForm.Designer.cs
@@ -118,6 +118,8 @@ namespace Server
             this.RemoveMButton = new System.Windows.Forms.Button();
             this.AddMButton = new System.Windows.Forms.Button();
             this.MovementInfoPanel = new System.Windows.Forms.Panel();
+            this.label25 = new System.Windows.Forms.Label();
+            this.ConquestComboBox = new System.Windows.Forms.ComboBox();
             this.NeedMoveMCheckBox = new System.Windows.Forms.CheckBox();
             this.NeedHoleMCheckBox = new System.Windows.Forms.CheckBox();
             this.label22 = new System.Windows.Forms.Label();
@@ -144,6 +146,37 @@ namespace Server
             this.label32 = new System.Windows.Forms.Label();
             this.MZXtextBox = new System.Windows.Forms.TextBox();
             this.MZListlistBox = new System.Windows.Forms.ListBox();
+            this.tabPage5 = new System.Windows.Forms.TabPage();
+            this.panelEventRespawn = new System.Windows.Forms.Panel();
+            this.txtSpreadX = new System.Windows.Forms.TextBox();
+            this.label42 = new System.Windows.Forms.Label();
+            this.chkIsRespawnObjective = new System.Windows.Forms.CheckBox();
+            this.txtSpreadY = new System.Windows.Forms.TextBox();
+            this.label41 = new System.Windows.Forms.Label();
+            this.txtOrder = new System.Windows.Forms.TextBox();
+            this.label40 = new System.Windows.Forms.Label();
+            this.label28 = new System.Windows.Forms.Label();
+            this.txtEventRespawnMonCount = new System.Windows.Forms.TextBox();
+            this.label35 = new System.Windows.Forms.Label();
+            this.txtEventRespawnMonName = new System.Windows.Forms.TextBox();
+            this.BtnRemoveEventRespawn = new System.Windows.Forms.Button();
+            this.btnAddEventRespawn = new System.Windows.Forms.Button();
+            this.lstEventRespawns = new System.Windows.Forms.ListBox();
+            this.panelEventInfo = new System.Windows.Forms.Panel();
+            this.chkIsSafeZone = new System.Windows.Forms.CheckBox();
+            this.ddlEventType = new System.Windows.Forms.ComboBox();
+            this.label39 = new System.Windows.Forms.Label();
+            this.label38 = new System.Windows.Forms.Label();
+            this.txtCooldownInMins = new System.Windows.Forms.TextBox();
+            this.label37 = new System.Windows.Forms.Label();
+            this.txtEventSize = new System.Windows.Forms.TextBox();
+            this.label29 = new System.Windows.Forms.Label();
+            this.txtEventName = new System.Windows.Forms.TextBox();
+            this.label36 = new System.Windows.Forms.Label();
+            this.txtEventMultipleCoords = new System.Windows.Forms.TextBox();
+            this.btnRemoveEvent = new System.Windows.Forms.Button();
+            this.btnAddEvent = new System.Windows.Forms.Button();
+            this.lstEventInfos = new System.Windows.Forms.ListBox();
             this.RemoveButton = new System.Windows.Forms.Button();
             this.AddButton = new System.Windows.Forms.Button();
             this.MapInfoListBox = new System.Windows.Forms.ListBox();
@@ -155,8 +188,6 @@ namespace Server
             this.ExportMongenButton = new System.Windows.Forms.Button();
             this.VisualizerButton = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.ConquestComboBox = new System.Windows.Forms.ComboBox();
-            this.label25 = new System.Windows.Forms.Label();
             this.MapTabs.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.tabPage6.SuspendLayout();
@@ -168,6 +199,9 @@ namespace Server
             this.MovementInfoPanel.SuspendLayout();
             this.tabPage7.SuspendLayout();
             this.MineZonepanel.SuspendLayout();
+            this.tabPage5.SuspendLayout();
+            this.panelEventRespawn.SuspendLayout();
+            this.panelEventInfo.SuspendLayout();
             this.SuspendLayout();
             // 
             // MapTabs
@@ -181,6 +215,7 @@ namespace Server
             this.MapTabs.Controls.Add(this.tabPage2);
             this.MapTabs.Controls.Add(this.tabPage4);
             this.MapTabs.Controls.Add(this.tabPage7);
+            this.MapTabs.Controls.Add(this.tabPage5);
             this.MapTabs.Location = new System.Drawing.Point(207, 62);
             this.MapTabs.Name = "MapTabs";
             this.MapTabs.SelectedIndex = 0;
@@ -1088,6 +1123,25 @@ namespace Server
             this.MovementInfoPanel.Size = new System.Drawing.Size(256, 205);
             this.MovementInfoPanel.TabIndex = 14;
             // 
+            // label25
+            // 
+            this.label25.AutoSize = true;
+            this.label25.Location = new System.Drawing.Point(3, 171);
+            this.label25.Name = "label25";
+            this.label25.Size = new System.Drawing.Size(55, 13);
+            this.label25.TabIndex = 20;
+            this.label25.Text = "Conquest:";
+            // 
+            // ConquestComboBox
+            // 
+            this.ConquestComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.ConquestComboBox.FormattingEnabled = true;
+            this.ConquestComboBox.Location = new System.Drawing.Point(64, 168);
+            this.ConquestComboBox.Name = "ConquestComboBox";
+            this.ConquestComboBox.Size = new System.Drawing.Size(182, 21);
+            this.ConquestComboBox.TabIndex = 19;
+            this.ConquestComboBox.SelectedIndexChanged += new System.EventHandler(this.ConquestComboBox_SelectedIndexChanged);
+            // 
             // NeedMoveMCheckBox
             // 
             this.NeedMoveMCheckBox.AutoSize = true;
@@ -1352,6 +1406,334 @@ namespace Server
             this.MZListlistBox.TabIndex = 13;
             this.MZListlistBox.SelectedIndexChanged += new System.EventHandler(this.MZListlistBox_SelectedIndexChanged);
             // 
+            // tabPage5
+            // 
+            this.tabPage5.Controls.Add(this.panelEventRespawn);
+            this.tabPage5.Controls.Add(this.BtnRemoveEventRespawn);
+            this.tabPage5.Controls.Add(this.btnAddEventRespawn);
+            this.tabPage5.Controls.Add(this.lstEventRespawns);
+            this.tabPage5.Controls.Add(this.panelEventInfo);
+            this.tabPage5.Controls.Add(this.btnRemoveEvent);
+            this.tabPage5.Controls.Add(this.btnAddEvent);
+            this.tabPage5.Controls.Add(this.lstEventInfos);
+            this.tabPage5.Location = new System.Drawing.Point(4, 22);
+            this.tabPage5.Name = "tabPage5";
+            this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage5.Size = new System.Drawing.Size(532, 247);
+            this.tabPage5.TabIndex = 7;
+            this.tabPage5.Text = "Events";
+            this.tabPage5.UseVisualStyleBackColor = true;
+            // 
+            // panelEventRespawn
+            // 
+            this.panelEventRespawn.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelEventRespawn.Controls.Add(this.txtSpreadX);
+            this.panelEventRespawn.Controls.Add(this.label42);
+            this.panelEventRespawn.Controls.Add(this.chkIsRespawnObjective);
+            this.panelEventRespawn.Controls.Add(this.txtSpreadY);
+            this.panelEventRespawn.Controls.Add(this.label41);
+            this.panelEventRespawn.Controls.Add(this.txtOrder);
+            this.panelEventRespawn.Controls.Add(this.label40);
+            this.panelEventRespawn.Controls.Add(this.label28);
+            this.panelEventRespawn.Controls.Add(this.txtEventRespawnMonCount);
+            this.panelEventRespawn.Controls.Add(this.label35);
+            this.panelEventRespawn.Controls.Add(this.txtEventRespawnMonName);
+            this.panelEventRespawn.Enabled = false;
+            this.panelEventRespawn.Location = new System.Drawing.Point(374, 108);
+            this.panelEventRespawn.Name = "panelEventRespawn";
+            this.panelEventRespawn.Size = new System.Drawing.Size(156, 139);
+            this.panelEventRespawn.TabIndex = 25;
+            // 
+            // txtSpreadX
+            // 
+            this.txtSpreadX.Location = new System.Drawing.Point(56, 50);
+            this.txtSpreadX.MaxLength = 2;
+            this.txtSpreadX.Name = "txtSpreadX";
+            this.txtSpreadX.Size = new System.Drawing.Size(95, 20);
+            this.txtSpreadX.TabIndex = 22;
+            this.txtSpreadX.TextChanged += new System.EventHandler(this.txtSpreadX_TextChanged);
+            // 
+            // label42
+            // 
+            this.label42.AutoSize = true;
+            this.label42.Location = new System.Drawing.Point(4, 52);
+            this.label42.Name = "label42";
+            this.label42.Size = new System.Drawing.Size(48, 13);
+            this.label42.TabIndex = 21;
+            this.label42.Text = "SpreadX";
+            // 
+            // chkIsRespawnObjective
+            // 
+            this.chkIsRespawnObjective.AutoSize = true;
+            this.chkIsRespawnObjective.Location = new System.Drawing.Point(7, 118);
+            this.chkIsRespawnObjective.Name = "chkIsRespawnObjective";
+            this.chkIsRespawnObjective.Size = new System.Drawing.Size(71, 17);
+            this.chkIsRespawnObjective.TabIndex = 20;
+            this.chkIsRespawnObjective.Text = "Objective";
+            this.chkIsRespawnObjective.UseVisualStyleBackColor = true;
+            this.chkIsRespawnObjective.CheckedChanged += new System.EventHandler(this.chkIsRespawnObjective_CheckedChanged);
+            // 
+            // txtSpreadY
+            // 
+            this.txtSpreadY.Location = new System.Drawing.Point(56, 72);
+            this.txtSpreadY.MaxLength = 2;
+            this.txtSpreadY.Name = "txtSpreadY";
+            this.txtSpreadY.Size = new System.Drawing.Size(95, 20);
+            this.txtSpreadY.TabIndex = 14;
+            this.txtSpreadY.TextChanged += new System.EventHandler(this.txtSpreadY_TextChanged);
+            // 
+            // label41
+            // 
+            this.label41.AutoSize = true;
+            this.label41.Location = new System.Drawing.Point(4, 75);
+            this.label41.Name = "label41";
+            this.label41.Size = new System.Drawing.Size(48, 13);
+            this.label41.TabIndex = 13;
+            this.label41.Text = "SpreadY";
+            // 
+            // txtOrder
+            // 
+            this.txtOrder.Location = new System.Drawing.Point(56, 98);
+            this.txtOrder.MaxLength = 5;
+            this.txtOrder.Name = "txtOrder";
+            this.txtOrder.Size = new System.Drawing.Size(95, 20);
+            this.txtOrder.TabIndex = 12;
+            this.txtOrder.TextChanged += new System.EventHandler(this.txtOrder_TextChanged);
+            // 
+            // label40
+            // 
+            this.label40.AutoSize = true;
+            this.label40.Location = new System.Drawing.Point(4, 100);
+            this.label40.Name = "label40";
+            this.label40.Size = new System.Drawing.Size(33, 13);
+            this.label40.TabIndex = 11;
+            this.label40.Text = "Order";
+            // 
+            // label28
+            // 
+            this.label28.AutoSize = true;
+            this.label28.Location = new System.Drawing.Point(4, 29);
+            this.label28.Name = "label28";
+            this.label28.Size = new System.Drawing.Size(38, 13);
+            this.label28.TabIndex = 10;
+            this.label28.Text = "Count ";
+            // 
+            // txtEventRespawnMonCount
+            // 
+            this.txtEventRespawnMonCount.Location = new System.Drawing.Point(56, 27);
+            this.txtEventRespawnMonCount.MaxLength = 2;
+            this.txtEventRespawnMonCount.Name = "txtEventRespawnMonCount";
+            this.txtEventRespawnMonCount.Size = new System.Drawing.Size(95, 20);
+            this.txtEventRespawnMonCount.TabIndex = 9;
+            this.txtEventRespawnMonCount.TextChanged += new System.EventHandler(this.txtEventRespawnMonCount_TextChanged);
+            // 
+            // label35
+            // 
+            this.label35.AutoSize = true;
+            this.label35.Location = new System.Drawing.Point(3, 6);
+            this.label35.Name = "label35";
+            this.label35.Size = new System.Drawing.Size(48, 13);
+            this.label35.TabIndex = 8;
+            this.label35.Text = "Monster ";
+            // 
+            // txtEventRespawnMonName
+            // 
+            this.txtEventRespawnMonName.Location = new System.Drawing.Point(56, 3);
+            this.txtEventRespawnMonName.MaxLength = 50;
+            this.txtEventRespawnMonName.Name = "txtEventRespawnMonName";
+            this.txtEventRespawnMonName.Size = new System.Drawing.Size(95, 20);
+            this.txtEventRespawnMonName.TabIndex = 4;
+            this.txtEventRespawnMonName.TextChanged += new System.EventHandler(this.txtEventRespawnMonName_TextChanged);
+            // 
+            // BtnRemoveEventRespawn
+            // 
+            this.BtnRemoveEventRespawn.Location = new System.Drawing.Point(468, 8);
+            this.BtnRemoveEventRespawn.Name = "BtnRemoveEventRespawn";
+            this.BtnRemoveEventRespawn.Size = new System.Drawing.Size(62, 23);
+            this.BtnRemoveEventRespawn.TabIndex = 24;
+            this.BtnRemoveEventRespawn.Text = "Remove";
+            this.BtnRemoveEventRespawn.UseVisualStyleBackColor = true;
+            this.BtnRemoveEventRespawn.Click += new System.EventHandler(this.BtnRemoveEventRespawn_Click);
+            // 
+            // btnAddEventRespawn
+            // 
+            this.btnAddEventRespawn.Location = new System.Drawing.Point(373, 8);
+            this.btnAddEventRespawn.Name = "btnAddEventRespawn";
+            this.btnAddEventRespawn.Size = new System.Drawing.Size(64, 23);
+            this.btnAddEventRespawn.TabIndex = 23;
+            this.btnAddEventRespawn.Text = "Add";
+            this.btnAddEventRespawn.UseVisualStyleBackColor = true;
+            this.btnAddEventRespawn.Click += new System.EventHandler(this.btnAddEventRespawn_Click);
+            // 
+            // lstEventRespawns
+            // 
+            this.lstEventRespawns.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.lstEventRespawns.FormattingEnabled = true;
+            this.lstEventRespawns.Location = new System.Drawing.Point(375, 35);
+            this.lstEventRespawns.Name = "lstEventRespawns";
+            this.lstEventRespawns.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+            this.lstEventRespawns.Size = new System.Drawing.Size(154, 69);
+            this.lstEventRespawns.TabIndex = 22;
+            this.lstEventRespawns.SelectedIndexChanged += new System.EventHandler(this.lstEventRespawns_SelectedIndexChanged);
+            // 
+            // panelEventInfo
+            // 
+            this.panelEventInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelEventInfo.Controls.Add(this.chkIsSafeZone);
+            this.panelEventInfo.Controls.Add(this.ddlEventType);
+            this.panelEventInfo.Controls.Add(this.label39);
+            this.panelEventInfo.Controls.Add(this.label38);
+            this.panelEventInfo.Controls.Add(this.txtCooldownInMins);
+            this.panelEventInfo.Controls.Add(this.label37);
+            this.panelEventInfo.Controls.Add(this.txtEventSize);
+            this.panelEventInfo.Controls.Add(this.label29);
+            this.panelEventInfo.Controls.Add(this.txtEventName);
+            this.panelEventInfo.Controls.Add(this.label36);
+            this.panelEventInfo.Controls.Add(this.txtEventMultipleCoords);
+            this.panelEventInfo.Enabled = false;
+            this.panelEventInfo.Location = new System.Drawing.Point(161, 8);
+            this.panelEventInfo.Name = "panelEventInfo";
+            this.panelEventInfo.Size = new System.Drawing.Size(210, 229);
+            this.panelEventInfo.TabIndex = 21;
+            // 
+            // chkIsSafeZone
+            // 
+            this.chkIsSafeZone.AutoSize = true;
+            this.chkIsSafeZone.Location = new System.Drawing.Point(113, 32);
+            this.chkIsSafeZone.Name = "chkIsSafeZone";
+            this.chkIsSafeZone.Size = new System.Drawing.Size(84, 17);
+            this.chkIsSafeZone.TabIndex = 18;
+            this.chkIsSafeZone.Text = "Is SafeZone";
+            this.chkIsSafeZone.UseVisualStyleBackColor = true;
+            this.chkIsSafeZone.CheckedChanged += new System.EventHandler(this.chkIsSafeZone_CheckedChanged);
+            // 
+            // ddlEventType
+            // 
+            this.ddlEventType.FormattingEnabled = true;
+            this.ddlEventType.Location = new System.Drawing.Point(6, 30);
+            this.ddlEventType.Name = "ddlEventType";
+            this.ddlEventType.Size = new System.Drawing.Size(103, 21);
+            this.ddlEventType.TabIndex = 17;
+            this.ddlEventType.SelectedIndexChanged += new System.EventHandler(this.ddlEventType_SelectedIndexChanged);
+            // 
+            // label39
+            // 
+            this.label39.AutoSize = true;
+            this.label39.Location = new System.Drawing.Point(1, 14);
+            this.label39.Name = "label39";
+            this.label39.Size = new System.Drawing.Size(62, 13);
+            this.label39.TabIndex = 16;
+            this.label39.Text = "Event Type";
+            // 
+            // label38
+            // 
+            this.label38.AutoSize = true;
+            this.label38.Location = new System.Drawing.Point(3, 184);
+            this.label38.Name = "label38";
+            this.label38.Size = new System.Drawing.Size(106, 13);
+            this.label38.TabIndex = 14;
+            this.label38.Text = "Cooldown In Minutes";
+            // 
+            // txtCooldownInMins
+            // 
+            this.txtCooldownInMins.Location = new System.Drawing.Point(5, 200);
+            this.txtCooldownInMins.MaxLength = 5;
+            this.txtCooldownInMins.Name = "txtCooldownInMins";
+            this.txtCooldownInMins.Size = new System.Drawing.Size(181, 20);
+            this.txtCooldownInMins.TabIndex = 13;
+            this.txtCooldownInMins.TextChanged += new System.EventHandler(this.txtCooldownInMins_TextChanged);
+            // 
+            // label37
+            // 
+            this.label37.AutoSize = true;
+            this.label37.Location = new System.Drawing.Point(2, 142);
+            this.label37.Name = "label37";
+            this.label37.Size = new System.Drawing.Size(58, 13);
+            this.label37.TabIndex = 12;
+            this.label37.Text = "Event Size";
+            // 
+            // txtEventSize
+            // 
+            this.txtEventSize.Location = new System.Drawing.Point(5, 158);
+            this.txtEventSize.MaxLength = 5;
+            this.txtEventSize.Name = "txtEventSize";
+            this.txtEventSize.Size = new System.Drawing.Size(181, 20);
+            this.txtEventSize.TabIndex = 11;
+            this.txtEventSize.TextChanged += new System.EventHandler(this.txtEventSize_TextChanged);
+            // 
+            // label29
+            // 
+            this.label29.AutoSize = true;
+            this.label29.Location = new System.Drawing.Point(3, 56);
+            this.label29.Name = "label29";
+            this.label29.Size = new System.Drawing.Size(66, 13);
+            this.label29.TabIndex = 10;
+            this.label29.Text = "Event Name";
+            // 
+            // txtEventName
+            // 
+            this.txtEventName.Location = new System.Drawing.Point(5, 75);
+            this.txtEventName.MaxLength = 50;
+            this.txtEventName.Name = "txtEventName";
+            this.txtEventName.Size = new System.Drawing.Size(181, 20);
+            this.txtEventName.TabIndex = 1;
+            this.txtEventName.TextChanged += new System.EventHandler(this.txtEventName_TextChanged);
+            // 
+            // label36
+            // 
+            this.label36.AutoSize = true;
+            this.label36.Location = new System.Drawing.Point(2, 101);
+            this.label36.Name = "label36";
+            this.label36.Size = new System.Drawing.Size(109, 13);
+            this.label36.TabIndex = 8;
+            this.label36.Text = "Multiple Coords (CSV)";
+            // 
+            // txtEventMultipleCoords
+            // 
+            this.txtEventMultipleCoords.Location = new System.Drawing.Point(5, 117);
+            this.txtEventMultipleCoords.MaxLength = 200;
+            this.txtEventMultipleCoords.Name = "txtEventMultipleCoords";
+            this.txtEventMultipleCoords.Size = new System.Drawing.Size(181, 20);
+            this.txtEventMultipleCoords.TabIndex = 4;
+            this.txtEventMultipleCoords.TextChanged += new System.EventHandler(this.txtEventMultipleCoords_TextChanged);
+            // 
+            // btnRemoveEvent
+            // 
+            this.btnRemoveEvent.Location = new System.Drawing.Point(77, 12);
+            this.btnRemoveEvent.Name = "btnRemoveEvent";
+            this.btnRemoveEvent.Size = new System.Drawing.Size(64, 23);
+            this.btnRemoveEvent.TabIndex = 20;
+            this.btnRemoveEvent.Text = "Remove";
+            this.btnRemoveEvent.UseVisualStyleBackColor = true;
+            this.btnRemoveEvent.Click += new System.EventHandler(this.btnRemoveEvent_Click);
+            // 
+            // btnAddEvent
+            // 
+            this.btnAddEvent.Location = new System.Drawing.Point(6, 12);
+            this.btnAddEvent.Name = "btnAddEvent";
+            this.btnAddEvent.Size = new System.Drawing.Size(56, 23);
+            this.btnAddEvent.TabIndex = 19;
+            this.btnAddEvent.Text = "Add";
+            this.btnAddEvent.UseVisualStyleBackColor = true;
+            this.btnAddEvent.Click += new System.EventHandler(this.btnAddEvent_Click);
+            // 
+            // lstEventInfos
+            // 
+            this.lstEventInfos.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.lstEventInfos.FormattingEnabled = true;
+            this.lstEventInfos.Location = new System.Drawing.Point(6, 41);
+            this.lstEventInfos.Name = "lstEventInfos";
+            this.lstEventInfos.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+            this.lstEventInfos.Size = new System.Drawing.Size(134, 199);
+            this.lstEventInfos.TabIndex = 18;
+            this.lstEventInfos.SelectedIndexChanged += new System.EventHandler(this.lstEventInfos_SelectedIndexChanged);
+            // 
             // RemoveButton
             // 
             this.RemoveButton.Location = new System.Drawing.Point(126, 33);
@@ -1453,25 +1835,6 @@ namespace Server
             this.VisualizerButton.UseVisualStyleBackColor = true;
             this.VisualizerButton.Click += new System.EventHandler(this.VisualizerButton_Click);
             // 
-            // ConquestComboBox
-            // 
-            this.ConquestComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.ConquestComboBox.FormattingEnabled = true;
-            this.ConquestComboBox.Location = new System.Drawing.Point(64, 168);
-            this.ConquestComboBox.Name = "ConquestComboBox";
-            this.ConquestComboBox.Size = new System.Drawing.Size(182, 21);
-            this.ConquestComboBox.TabIndex = 19;
-            this.ConquestComboBox.SelectedIndexChanged += new System.EventHandler(this.ConquestComboBox_SelectedIndexChanged);
-            // 
-            // label25
-            // 
-            this.label25.AutoSize = true;
-            this.label25.Location = new System.Drawing.Point(3, 171);
-            this.label25.Name = "label25";
-            this.label25.Size = new System.Drawing.Size(55, 13);
-            this.label25.TabIndex = 20;
-            this.label25.Text = "Conquest:";
-            // 
             // MapInfoForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1508,6 +1871,11 @@ namespace Server
             this.tabPage7.ResumeLayout(false);
             this.MineZonepanel.ResumeLayout(false);
             this.MineZonepanel.PerformLayout();
+            this.tabPage5.ResumeLayout(false);
+            this.panelEventRespawn.ResumeLayout(false);
+            this.panelEventRespawn.PerformLayout();
+            this.panelEventInfo.ResumeLayout(false);
+            this.panelEventInfo.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -1637,5 +2005,36 @@ namespace Server
         private CheckBox chkRespawnEnableTick;
         private ComboBox ConquestComboBox;
         private Label label25;
+        private TabPage tabPage5;
+        private Panel panelEventRespawn;
+        private TextBox txtSpreadX;
+        private Label label42;
+        private CheckBox chkIsRespawnObjective;
+        private TextBox txtSpreadY;
+        private Label label41;
+        private TextBox txtOrder;
+        private Label label40;
+        private Label label28;
+        private TextBox txtEventRespawnMonCount;
+        private Label label35;
+        private TextBox txtEventRespawnMonName;
+        private Button BtnRemoveEventRespawn;
+        private Button btnAddEventRespawn;
+        private ListBox lstEventRespawns;
+        private Panel panelEventInfo;
+        private CheckBox chkIsSafeZone;
+        private ComboBox ddlEventType;
+        private Label label39;
+        private Label label38;
+        private TextBox txtCooldownInMins;
+        private Label label37;
+        private TextBox txtEventSize;
+        private Label label29;
+        private TextBox txtEventName;
+        private Label label36;
+        private TextBox txtEventMultipleCoords;
+        private Button btnRemoveEvent;
+        private Button btnAddEvent;
+        private ListBox lstEventInfos;
     }
 }

--- a/Server/MirForms/Database/MapInfoForm.Designer.cs
+++ b/Server/MirForms/Database/MapInfoForm.Designer.cs
@@ -163,6 +163,8 @@ namespace Server
             this.btnAddEventRespawn = new System.Windows.Forms.Button();
             this.lstEventRespawns = new System.Windows.Forms.ListBox();
             this.panelEventInfo = new System.Windows.Forms.Panel();
+            this.label26 = new System.Windows.Forms.Label();
+            this.txtObjectiveMsg = new System.Windows.Forms.TextBox();
             this.chkIsSafeZone = new System.Windows.Forms.CheckBox();
             this.ddlEventType = new System.Windows.Forms.ComboBox();
             this.label39 = new System.Windows.Forms.Label();
@@ -1584,6 +1586,8 @@ namespace Server
             this.panelEventInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelEventInfo.Controls.Add(this.label26);
+            this.panelEventInfo.Controls.Add(this.txtObjectiveMsg);
             this.panelEventInfo.Controls.Add(this.chkIsSafeZone);
             this.panelEventInfo.Controls.Add(this.ddlEventType);
             this.panelEventInfo.Controls.Add(this.label39);
@@ -1601,10 +1605,28 @@ namespace Server
             this.panelEventInfo.Size = new System.Drawing.Size(210, 229);
             this.panelEventInfo.TabIndex = 21;
             // 
+            // label26
+            // 
+            this.label26.AutoSize = true;
+            this.label26.Location = new System.Drawing.Point(3, 187);
+            this.label26.Name = "label26";
+            this.label26.Size = new System.Drawing.Size(98, 13);
+            this.label26.TabIndex = 20;
+            this.label26.Text = "Objective Message";
+            // 
+            // txtObjectiveMsg
+            // 
+            this.txtObjectiveMsg.Location = new System.Drawing.Point(4, 203);
+            this.txtObjectiveMsg.MaxLength = 100;
+            this.txtObjectiveMsg.Name = "txtObjectiveMsg";
+            this.txtObjectiveMsg.Size = new System.Drawing.Size(202, 20);
+            this.txtObjectiveMsg.TabIndex = 19;
+            this.txtObjectiveMsg.TextChanged += new System.EventHandler(this.txtObjectiveMsg_TextChanged);
+            // 
             // chkIsSafeZone
             // 
             this.chkIsSafeZone.AutoSize = true;
-            this.chkIsSafeZone.Location = new System.Drawing.Point(113, 32);
+            this.chkIsSafeZone.Location = new System.Drawing.Point(122, 30);
             this.chkIsSafeZone.Name = "chkIsSafeZone";
             this.chkIsSafeZone.Size = new System.Drawing.Size(84, 17);
             this.chkIsSafeZone.TabIndex = 18;
@@ -1617,7 +1639,7 @@ namespace Server
             this.ddlEventType.FormattingEnabled = true;
             this.ddlEventType.Location = new System.Drawing.Point(6, 30);
             this.ddlEventType.Name = "ddlEventType";
-            this.ddlEventType.Size = new System.Drawing.Size(103, 21);
+            this.ddlEventType.Size = new System.Drawing.Size(110, 21);
             this.ddlEventType.TabIndex = 17;
             this.ddlEventType.SelectedIndexChanged += new System.EventHandler(this.ddlEventType_SelectedIndexChanged);
             // 
@@ -1633,18 +1655,18 @@ namespace Server
             // label38
             // 
             this.label38.AutoSize = true;
-            this.label38.Location = new System.Drawing.Point(3, 184);
+            this.label38.Location = new System.Drawing.Point(115, 142);
             this.label38.Name = "label38";
-            this.label38.Size = new System.Drawing.Size(106, 13);
+            this.label38.Size = new System.Drawing.Size(77, 13);
             this.label38.TabIndex = 14;
-            this.label38.Text = "Cooldown In Minutes";
+            this.label38.Text = "Cooldown(Min)";
             // 
             // txtCooldownInMins
             // 
-            this.txtCooldownInMins.Location = new System.Drawing.Point(5, 200);
+            this.txtCooldownInMins.Location = new System.Drawing.Point(115, 158);
             this.txtCooldownInMins.MaxLength = 5;
             this.txtCooldownInMins.Name = "txtCooldownInMins";
-            this.txtCooldownInMins.Size = new System.Drawing.Size(181, 20);
+            this.txtCooldownInMins.Size = new System.Drawing.Size(91, 20);
             this.txtCooldownInMins.TabIndex = 13;
             this.txtCooldownInMins.TextChanged += new System.EventHandler(this.txtCooldownInMins_TextChanged);
             // 
@@ -1662,7 +1684,7 @@ namespace Server
             this.txtEventSize.Location = new System.Drawing.Point(5, 158);
             this.txtEventSize.MaxLength = 5;
             this.txtEventSize.Name = "txtEventSize";
-            this.txtEventSize.Size = new System.Drawing.Size(181, 20);
+            this.txtEventSize.Size = new System.Drawing.Size(104, 20);
             this.txtEventSize.TabIndex = 11;
             this.txtEventSize.TextChanged += new System.EventHandler(this.txtEventSize_TextChanged);
             // 
@@ -1680,7 +1702,7 @@ namespace Server
             this.txtEventName.Location = new System.Drawing.Point(5, 75);
             this.txtEventName.MaxLength = 50;
             this.txtEventName.Name = "txtEventName";
-            this.txtEventName.Size = new System.Drawing.Size(181, 20);
+            this.txtEventName.Size = new System.Drawing.Size(201, 20);
             this.txtEventName.TabIndex = 1;
             this.txtEventName.TextChanged += new System.EventHandler(this.txtEventName_TextChanged);
             // 
@@ -1698,7 +1720,7 @@ namespace Server
             this.txtEventMultipleCoords.Location = new System.Drawing.Point(5, 117);
             this.txtEventMultipleCoords.MaxLength = 200;
             this.txtEventMultipleCoords.Name = "txtEventMultipleCoords";
-            this.txtEventMultipleCoords.Size = new System.Drawing.Size(181, 20);
+            this.txtEventMultipleCoords.Size = new System.Drawing.Size(201, 20);
             this.txtEventMultipleCoords.TabIndex = 4;
             this.txtEventMultipleCoords.TextChanged += new System.EventHandler(this.txtEventMultipleCoords_TextChanged);
             // 
@@ -2036,5 +2058,7 @@ namespace Server
         private Button btnRemoveEvent;
         private Button btnAddEvent;
         private ListBox lstEventInfos;
+        private Label label26;
+        private TextBox txtObjectiveMsg;
     }
 }

--- a/Server/MirForms/Database/MapInfoForm.cs
+++ b/Server/MirForms/Database/MapInfoForm.cs
@@ -23,6 +23,9 @@ namespace Server
         private List<RespawnInfo> _selectedRespawnInfos;
         private List<MovementInfo> _selectedMovementInfos;
         private List<MineZone> _selectedMineZones;
+        private List<PublicEventInfo> _selectedEvents;
+        private List<EventRespawn> _selectedEventRespawns;
+
         private MapInfo _info;
 
         public MapInfoForm()
@@ -40,6 +43,10 @@ namespace Server
 
             ConquestComboBox.Items.Add(new ListItem("None", "0"));
             for (int i = 0; i < Envir.ConquestInfos.Count; i++) ConquestComboBox.Items.Add(Envir.ConquestInfos[i]);
+
+
+            ddlEventType.Items.AddRange(Enum.GetValues(typeof(EventType)).Cast<object>().ToArray());
+            ddlEventType.Select(0, 0);
 
             UpdateInterface();
         }
@@ -185,6 +192,93 @@ namespace Server
             UpdateRespawnInterface();
             UpdateMovementInterface();
             UpdateMineZoneInterface();
+            UpdateEventsInterface();
+        }
+        private void UpdateEventsInterface()
+        {
+            if (_selectedMapInfos.Count != 1)
+            {
+                lstEventInfos.Items.Clear();
+                if (_selectedEvents != null && _selectedEvents.Count > 0)
+                    _selectedEvents.Clear();
+                _info = null;
+                return;
+            }
+
+            if (_info != _selectedMapInfos[0])
+            {
+                lstEventInfos.Items.Clear();
+                _info = _selectedMapInfos[0];
+            }
+
+            if (lstEventInfos.Items.Count != _info.PublicEvents.Count)
+            {
+                lstEventInfos.Items.Clear();
+                for (int i = 0; i < _info.PublicEvents.Count; i++) lstEventInfos.Items.Add(_info.PublicEvents[i]);
+            }
+            _selectedEvents = lstEventInfos.SelectedItems.Cast<PublicEventInfo>().ToList();
+
+            if (_selectedEvents.Count == 0)
+            {
+                //Clear Text
+                txtCooldownInMins.Text = string.Empty;
+                txtEventMultipleCoords.Text = string.Empty;
+                txtEventName.Text = string.Empty;
+                txtEventSize.Text = string.Empty;
+                txtOrder.Text = string.Empty;
+                txtEventRespawnMonCount.Text = string.Empty;
+
+                return;
+            }
+
+            PublicEventInfo info = _selectedEvents[0];
+            txtCooldownInMins.Text = info.CooldownInMinutes.ToString();
+            txtEventMultipleCoords.Text = info.MultipleCoords.ToString();
+            txtEventName.Text = info.EventName.ToString();
+            txtEventSize.Text = info.EventSize.ToString();
+            panelEventInfo.Enabled = true;
+            ddlEventType.SelectedItem = (EventType)info.EventType;
+            chkIsSafeZone.Checked = info.IsSafezone;
+
+            lstEventRespawns.Items.Clear();
+            for (int i = 0; i < info.Respawns.Count; i++) lstEventRespawns.Items.Add(info.Respawns[i]);
+
+        }
+        private void UpdateEventRespawnInterface()
+        {
+            if (_selectedEvents == null || _selectedEvents.Count == 0)
+            {
+                lstEventRespawns.Items.Clear();
+                panelEventRespawn.Enabled = false;
+                return;
+            }
+
+            var selectedEventInfo = _selectedEvents.FirstOrDefault();
+            if (selectedEventInfo == null)
+                return;
+
+            if (lstEventRespawns.Items.Count != selectedEventInfo.Respawns.Count)
+            {
+                lstEventRespawns.Items.Clear();
+                for (int i = 0; i < selectedEventInfo.Respawns.Count; i++) lstEventRespawns.Items.Add(selectedEventInfo.Respawns[i]);
+            }
+            _selectedEventRespawns = lstEventRespawns.SelectedItems.Cast<EventRespawn>().ToList();
+
+            if (_selectedEventRespawns.Count == 0)
+            {
+                txtEventRespawnMonCount.Text = string.Empty;
+                txtEventRespawnMonName.Text = string.Empty;
+                return;
+            }
+
+            EventRespawn info = _selectedEventRespawns[0];
+            txtEventRespawnMonCount.Text = info.MonsterCount.ToString();
+            txtEventRespawnMonName.Text = info.MonsterName;
+            panelEventRespawn.Enabled = true;
+            txtOrder.Text = info.Order.ToString();
+            txtSpreadY.Text = info.SpreadY.ToString();
+            txtSpreadX.Text = info.SpreadX.ToString();
+            chkIsRespawnObjective.Checked = info.IsObjective;
         }
         private void UpdateSafeZoneInterface()
         {
@@ -517,6 +611,42 @@ namespace Server
             for (int i = 0; i < selected.Count; i++) MapInfoListBox.SetSelected(i, selected[i]);
 
             MapInfoListBox.SelectedIndexChanged += MapInfoListBox_SelectedIndexChanged;
+        }
+        private void RefreshPublicEventsList()
+        {
+            lstEventInfos.SelectedIndexChanged -= EventsListBox_SelectedIndexChanged;
+
+            List<bool> selected = new List<bool>();
+
+            for (int i = 0; i < lstEventInfos.Items.Count; i++) selected.Add(lstEventInfos.GetSelected(i));
+            lstEventInfos.Items.Clear();
+            for (int i = 0; i < _info.PublicEvents.Count; i++) lstEventInfos.Items.Add(_info.PublicEvents[i]);
+            for (int i = 0; i < selected.Count; i++) lstEventInfos.SetSelected(i, selected[i]);
+
+            lstEventInfos.SelectedIndexChanged += EventsListBox_SelectedIndexChanged;
+        }
+        private void EventsListBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            UpdateEventsInterface();
+        }
+
+
+        private void RefreshEventRespawnsList()
+        {
+            var selectedEvent = _selectedEvents.FirstOrDefault();
+            if (selectedEvent == null)
+                return;
+
+            lstEventRespawns.SelectedIndexChanged -= lstEventRespawns_SelectedIndexChanged;
+
+            List<bool> selected = new List<bool>();
+
+            for (int i = 0; i < lstEventRespawns.Items.Count; i++) selected.Add(lstEventRespawns.GetSelected(i));
+            lstEventRespawns.Items.Clear();
+            for (int i = 0; i < selectedEvent.Respawns.Count; i++) lstEventRespawns.Items.Add(selectedEvent.Respawns[i]);
+            for (int i = 0; i < selected.Count; i++) lstEventRespawns.SetSelected(i, selected[i]);
+
+            lstEventRespawns.SelectedIndexChanged += lstEventRespawns_SelectedIndexChanged;
         }
         private void RefreshSafeZoneList()
         {
@@ -1798,5 +1928,270 @@ namespace Server
 
             RefreshMovementList();
         }
+        private void btnAddEvent_Click(object sender, EventArgs e)
+        {
+            if (_info == null) return;
+
+            _info.CreatePublicEvent();
+            UpdateEventsInterface();
+        }
+
+        private void txtEventName_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEvents.Count; i++)
+                _selectedEvents[i].EventName = ActiveControl.Text;
+
+            //    RefreshPublicEventsList();
+        }
+
+        private void txtEventSize_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+
+            short temp;
+
+            if (!short.TryParse(ActiveControl.Text, out temp))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return;
+            }
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEvents.Count; i++)
+                _selectedEvents[i].EventSize = temp;
+
+            //   RefreshPublicEventsList();
+        }
+
+        private void txtCooldownInMins_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            int temp;
+
+            if (!int.TryParse(ActiveControl.Text, out temp))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return;
+            }
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEvents.Count; i++)
+                _selectedEvents[i].CooldownInMinutes = temp;
+
+            //            RefreshPublicEventsList();
+        }
+
+        private void txtEventMultipleCoords_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEvents.Count; i++)
+                _selectedEvents[i].MultipleCoords = ActiveControl.Text;
+
+        }
+
+        private void lstEventInfos_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            UpdateEventsInterface();
+        }
+
+        private void btnAddEventRespawn_Click(object sender, EventArgs e)
+        {
+            if (_selectedEvents == null)
+                return;
+
+            try
+            {
+                var info = _selectedEvents[0];
+                info.Respawns.Add(new EventRespawn());
+                UpdateEventRespawnInterface();
+            }
+            catch (Exception ex)
+            {
+                return;
+            }
+        }
+
+        private void lstEventRespawns_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            UpdateEventRespawnInterface();
+
+        }
+
+        private void txtEventRespawnMonName_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEventRespawns.Count; i++)
+                _selectedEventRespawns[i].MonsterName = ActiveControl.Text;
+
+            RefreshEventRespawnsList();
+        }
+
+        private void txtEventRespawnMonCount_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            ushort temp;
+
+            if (!ushort.TryParse(ActiveControl.Text, out temp))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return;
+            }
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEventRespawns.Count; i++)
+                _selectedEventRespawns[i].MonsterCount = temp;
+
+            RefreshEventRespawnsList();
+
+        }
+
+        private void btnRemoveEvent_Click(object sender, EventArgs e)
+        {
+
+            if (_selectedEvents.Count == 0) return;
+
+            if (MessageBox.Show("Are you sure you want to remove the selected Public Event?", "Remove Event?", MessageBoxButtons.YesNo) != DialogResult.Yes) return;
+
+            for (int i = 0; i < _selectedEvents.Count; i++) _info.PublicEvents.Remove(_selectedEvents[i]);
+
+            UpdateEventsInterface();
+        }
+
+        private void BtnRemoveEventRespawn_Click(object sender, EventArgs e)
+        {
+            if (_selectedEvents.Count == 0 || _selectedEventRespawns.Count == 0) return;
+
+            if (MessageBox.Show("Are you sure you want to remove the selected  Event Respawns?", "Remove Event Respawn ?", MessageBoxButtons.YesNo) != DialogResult.Yes) return;
+
+            var selectedEvent = _selectedEvents[0];
+            for (int i = 0; i < _selectedEventRespawns.Count; i++) selectedEvent.Respawns.Remove(_selectedEventRespawns[i]);
+
+            UpdateEventRespawnInterface();
+        }
+
+        private void ddlEventType_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+
+            for (int i = 0; i < _selectedEvents.Count; i++)
+                _selectedEvents[i].EventType = (EventType)ddlEventType.SelectedItem;
+        }
+
+        private void chkIsSafeZone_CheckedChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            for (int i = 0; i < _selectedEvents.Count; i++)
+                _selectedEvents[i].IsSafezone = chkIsSafeZone.Checked;
+
+        }
+
+        private void textBox1_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            ushort temp;
+
+            if (!ushort.TryParse(ActiveControl.Text, out temp))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return;
+            }
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEventRespawns.Count; i++)
+                _selectedEventRespawns[i].Order = temp;
+
+        }
+
+        private void txtSpread_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            ushort temp;
+
+            if (!ushort.TryParse(ActiveControl.Text, out temp))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return;
+            }
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEventRespawns.Count; i++)
+                _selectedEventRespawns[i].SpreadY = temp;
+        }
+        private void txtOrder_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            ushort temp;
+
+            if (!ushort.TryParse(ActiveControl.Text, out temp))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return;
+            }
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEventRespawns.Count; i++)
+                _selectedEventRespawns[i].Order = temp;
+
+        }
+        private void chkPatrol_CheckedChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+
+
+        }
+
+        private void chkIsRespawnObjective_CheckedChanged(object sender, EventArgs e)
+        {
+
+            if (ActiveControl != sender) return;
+            for (int i = 0; i < _selectedEventRespawns.Count; i++)
+                _selectedEventRespawns[i].IsObjective = chkIsRespawnObjective.Checked;
+        }
+
+        private void txtSpreadX_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            ushort temp;
+
+            if (!ushort.TryParse(ActiveControl.Text, out temp))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return;
+            }
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEventRespawns.Count; i++)
+                _selectedEventRespawns[i].SpreadX = temp;
+        }
+
+
+
+        private void txtSpreadY_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+            ushort temp;
+
+            if (!ushort.TryParse(ActiveControl.Text, out temp))
+            {
+                ActiveControl.BackColor = Color.Red;
+                return;
+            }
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEventRespawns.Count; i++)
+                _selectedEventRespawns[i].SpreadY = temp;
+
+        }
+
     }
 }

--- a/Server/MirForms/Database/MapInfoForm.cs
+++ b/Server/MirForms/Database/MapInfoForm.cs
@@ -227,6 +227,7 @@ namespace Server
                 txtEventSize.Text = string.Empty;
                 txtOrder.Text = string.Empty;
                 txtEventRespawnMonCount.Text = string.Empty;
+                txtObjectiveMsg.Text = string.Empty;
 
                 return;
             }
@@ -235,6 +236,8 @@ namespace Server
             txtCooldownInMins.Text = info.CooldownInMinutes.ToString();
             txtEventMultipleCoords.Text = info.MultipleCoords.ToString();
             txtEventName.Text = info.EventName.ToString();
+            txtObjectiveMsg.Text = info.ObjectiveMessage.ToString();
+
             txtEventSize.Text = info.EventSize.ToString();
             panelEventInfo.Enabled = true;
             ddlEventType.SelectedItem = (EventType)info.EventType;
@@ -2193,5 +2196,14 @@ namespace Server
 
         }
 
+        private void txtObjectiveMsg_TextChanged(object sender, EventArgs e)
+        {
+            if (ActiveControl != sender) return;
+
+            ActiveControl.BackColor = SystemColors.Window;
+
+            for (int i = 0; i < _selectedEvents.Count; i++)
+                _selectedEvents[i].ObjectiveMessage = ActiveControl.Text;
+        }
     }
 }

--- a/Server/MirForms/Database/MapInfoForm.resx
+++ b/Server/MirForms/Database/MapInfoForm.resx
@@ -120,7 +120,4 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/Server/MirObjects/ItemObject.cs
+++ b/Server/MirObjects/ItemObject.cs
@@ -371,6 +371,7 @@ namespace Server.MirObjects
                         Name = Item.Count > 1 ? string.Format("{0} ({1})", Name, Item.Count) : Name,
                         NameColour = NameColour,
                         Location = CurrentLocation,
+                        Grade = Item.Info.Grade,
                         Image = Item.Image
                     };
 

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -240,7 +240,10 @@ namespace Server.MirObjects
 
         public MonsterInfo Info;
         public MapRespawn Respawn;
-        
+        public List<PlayerObject> Contributers = new List<PlayerObject>();
+        public bool Retreat = false;
+        public Point SpawnedLocation;
+
         public override string Name
         {
             get { return Master == null ? Info.GameName : string.Format("{0}({1})", Info.GameName, Master.Name); }
@@ -426,6 +429,8 @@ namespace Server.MirObjects
         public override void Spawned()
         {
             base.Spawned();
+            SpawnedLocation = CurrentLocation;
+
             ActionTime = Envir.Time + 2000;
             if (Info.HasSpawnScript && (SMain.Envir.MonsterNPC != null))
             {
@@ -658,7 +663,13 @@ namespace Server.MirObjects
             }
 
             if (Respawn != null)
+            {
                 Respawn.Count--;
+                if (Respawn.IsEventObjective && Respawn.Event != null)
+                    Respawn.Event.EventMonsterDied(Contributers);
+
+                Contributers.Clear();
+            }
 
             if (Master == null && EXPOwner != null)
                  Drop();
@@ -1222,6 +1233,27 @@ namespace Server.MirObjects
         protected virtual void ProcessAI()
         {
             if (Dead) return;
+
+            if (Respawn != null && Respawn.IsEventObjective)
+            {
+                //if monster is 10 yards away from the spawned location it goes into retreat
+                if (!Functions.InRange(CurrentLocation, SpawnedLocation, 10))
+                {
+                    Retreat = true;
+                    ChangeHP((int)MaxHP);
+                }
+
+                if (Retreat)
+                {
+                    if (Functions.InRange(CurrentLocation, SpawnedLocation, 2))
+                        Retreat = false;
+                    else
+                    {
+                        MoveTo(SpawnedLocation);
+                        return;
+                    }
+                }
+            }
 
             if (Master != null)
             {
@@ -2087,6 +2119,12 @@ namespace Server.MirObjects
 
             BroadcastDamageIndicator(DamageType.Hit, armour - damage);
 
+            if (Respawn.IsEventObjective && attacker.tempEvent != null)
+            {
+                if (!Contributers.Contains(attacker))
+                    Contributers.Add(attacker);
+            }
+
             ChangeHP(armour - damage);
             return damage - armour;
         }
@@ -2175,6 +2213,13 @@ namespace Server.MirObjects
             Broadcast(new S.ObjectStruck { ObjectID = ObjectID, AttackerID = attacker.ObjectID, Direction = Direction, Location = CurrentLocation });
 
             BroadcastDamageIndicator(DamageType.Hit, armour - damage);
+
+            if (Respawn.IsEventObjective && attacker.Master != null && attacker.Master is PlayerObject)
+            {
+                var playerAttacker = (PlayerObject)attacker.Master;
+                if (!Contributers.Contains(playerAttacker) && playerAttacker.tempEvent != null)
+                    Contributers.Add(playerAttacker);
+            }
 
             ChangeHP(armour - damage);
             return damage - armour;

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -2217,7 +2217,7 @@ namespace Server.MirObjects
 
             BroadcastDamageIndicator(DamageType.Hit, armour - damage);
 
-            if (Respawn.IsEventObjective && attacker.Master != null && attacker.Master is PlayerObject)
+            if (Respawn != null && Respawn.IsEventObjective && attacker.Master != null && attacker.Master is PlayerObject)
             {
                 var playerAttacker = (PlayerObject)attacker.Master;
                 if (!Contributers.Contains(playerAttacker) && playerAttacker.tempEvent != null)

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -1236,15 +1236,18 @@ namespace Server.MirObjects
 
             if (Respawn != null && Respawn.IsEventObjective)
             {
-                //if monster is 10 yards away from the spawned location it goes into retreat
-                if (!Functions.InRange(CurrentLocation, SpawnedLocation, 10))
+                //if monster is 10 yards away from the spawned location it goes into retreat or monster is outside event area
+                if (!Retreat && (!Functions.InRange(CurrentLocation, SpawnedLocation, 10) || !Functions.InRange(Respawn.Event.CurrentLocation, CurrentLocation, Respawn.Event.Info.EventSize)))
                 {
                     Retreat = true;
-                    ChangeHP((int)MaxHP);
+                    Target = null;
                 }
 
                 if (Retreat)
                 {
+                    if (HP != MaxHP)
+                        ChangeHP((int)MaxHP);
+
                     if (Functions.InRange(CurrentLocation, SpawnedLocation, 2))
                         Retreat = false;
                     else

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -2122,7 +2122,7 @@ namespace Server.MirObjects
 
             BroadcastDamageIndicator(DamageType.Hit, armour - damage);
 
-            if (Respawn.IsEventObjective && attacker.tempEvent != null)
+            if (Respawn != null && Respawn.IsEventObjective && attacker.tempEvent != null)
             {
                 if (!Contributers.Contains(attacker))
                     Contributers.Add(attacker);

--- a/Server/MirObjects/NPCObject.cs
+++ b/Server/MirObjects/NPCObject.cs
@@ -115,6 +115,9 @@ namespace Server.MirObjects
 
             string fileName = Path.Combine(Settings.NPCPath, Info.FileName + ".txt");
 
+            if (Info.FileName.Contains("-Event-"))
+                fileName = Path.Combine(Settings.EventsPath, Info.FileName);
+
             if (File.Exists(fileName))
             {
                 List<string> lines = File.ReadAllLines(fileName).ToList();

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -19705,17 +19705,18 @@ namespace Server.MirObjects
             if (tempEvent == null)
                 return;
 
-            var monsterNames = tempEvent.MapRespawns.Select(mr => mr.Monster.Name).Distinct().ToList();
-            var obj = (string.Format("{0}", string.Join(",", monsterNames)));
 
-            var objectiveRespawns = tempEvent.MapRespawns.Where(p => p.IsEventObjective);
-            int totalMonstersAsObj = objectiveRespawns.Select(o => o.Info.Count).Sum(o => o);
-            int aliveMonstersCount = objectiveRespawns.Select(o => o.Count).Sum(o => o);
-            var deadMonsters = totalMonstersAsObj - aliveMonstersCount;
+            List<MonsterEventObjective> monObj = tempEvent.MapRespawns.Select(o => new MonsterEventObjective()
+            {
+                MonsterName = o.Monster.Name,
+                MonsterTotalCount = o.Info.Count,
+                MonsterAliveCount = o.Count
+            }).ToList();
 
-            var remainingCount = string.Format("{0}/{1}", aliveMonstersCount, totalMonstersAsObj);
-            var completedPerc = (int)(((decimal)deadMonsters / (decimal)totalMonstersAsObj) * 100);
-            var packet = new S.EnterOrUpdatePublicEvent(tempEvent.Info.EventName, obj, remainingCount, completedPerc, tempEvent.Stage);
+            //var remainingCount = string.Format("{0}/{1}", alive, total);
+            //var completedPerc = (int)(((decimal)dead / total) * 100);
+
+            var packet = new S.EnterOrUpdatePublicEvent(tempEvent.Info.EventName, tempEvent.Info.EventType, tempEvent.Info.ObjectiveMessage, tempEvent.Stage, monObj);
 
             Enqueue(packet);
             InSafeZone = tempEvent.Info.IsSafezone;

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -102,7 +102,9 @@
     </Compile>
     <Compile Include="MirDatabase\MailInfo.cs" />
     <Compile Include="MirDatabase\ConquestInfo.cs" />
+    <Compile Include="MirDatabase\MapEventInfo.cs" />
     <Compile Include="MirDatabase\RecipeInfo.cs" />
+    <Compile Include="MirEnvir\MapEvent.cs" />
     <Compile Include="MirEnvir\Reporting.cs" />
     <Compile Include="MirEnvir\RespawnTimer.cs" />
     <Compile Include="MirForms\Account\PlayerInfoForm.cs">

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -25,7 +25,9 @@ namespace Server
                             NameListPath = EnvirPath + @".\NameLists\",
                             ValuePath = EnvirPath + @".\Values\",
                             ReportPath = @".\Reports\",
-                            LogPath = @".\Logs\";
+                            LogPath = @".\Logs\",
+                            EventsPath = EnvirPath + @".\Events\";
+
 
 
 

--- a/ServerPackets.cs
+++ b/ServerPackets.cs
@@ -5670,37 +5670,43 @@ namespace ServerPackets
         public override short Index { get { return (short)ServerPacketIds.EnterPublicEvent; } }
 
         public string EventName = string.Empty;
-        public string Objective = string.Empty;
-        public int CompletedPercentage = 0;
-        public string RemainingCount = string.Empty;
+        public string ObjectiveMessage = string.Empty;
+        public List<MonsterEventObjective> Objectives = new List<MonsterEventObjective>();
         public int Stage = 0;
+        public EventType Type = EventType.None;
         public EnterOrUpdatePublicEvent()
         {
 
         }
-        public EnterOrUpdatePublicEvent(string eventName, string objective, string remainingCount, int completedPercentage, int stage)
+        public EnterOrUpdatePublicEvent(string eventName, EventType type, string objective, int stage,List<MonsterEventObjective> monsters)
         {
             EventName = eventName;
-            Objective = objective;
-            RemainingCount = remainingCount;
+            ObjectiveMessage = objective;
             Stage = stage;
-            CompletedPercentage = completedPercentage;
+            Type = type;
+            Objectives = monsters;
         }
         protected override void ReadPacket(BinaryReader reader)
         {
             EventName = reader.ReadString();
-            Objective = reader.ReadString();
-            RemainingCount = reader.ReadString();
-            CompletedPercentage = reader.ReadInt32();
+            ObjectiveMessage = reader.ReadString();
             Stage = reader.ReadInt32();
+
+            int count = reader.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                Objectives.Add(new MonsterEventObjective(reader));
+            }
         }
         protected override void WritePacket(BinaryWriter writer)
         {
             writer.Write(EventName);
-            writer.Write(Objective);
-            writer.Write(RemainingCount);
-            writer.Write(CompletedPercentage);
+            writer.Write(ObjectiveMessage);
             writer.Write(Stage);
+            writer.Write(Objectives.Count);
+
+            foreach (var obj in Objectives)
+                obj.Save(writer);
         }
     }
     public sealed class LeavePublicEvent : Packet

--- a/ServerPackets.cs
+++ b/ServerPackets.cs
@@ -1749,7 +1749,7 @@ namespace ServerPackets
         public Color NameColour;
         public Point Location;
         public ushort Image;
-        public ItemGrade grade;
+        public ItemGrade Grade;
 
 
         protected override void ReadPacket(BinaryReader reader)
@@ -1759,7 +1759,7 @@ namespace ServerPackets
             NameColour = Color.FromArgb(reader.ReadInt32());
             Location = new Point(reader.ReadInt32(), reader.ReadInt32());
             Image = reader.ReadUInt16();
-            grade = (ItemGrade)reader.ReadByte();
+            Grade = (ItemGrade)reader.ReadByte();
 		}
 
         protected override void WritePacket(BinaryWriter writer)
@@ -1770,7 +1770,7 @@ namespace ServerPackets
             writer.Write(Location.X);
             writer.Write(Location.Y);
             writer.Write(Image);
-            writer.Write((byte)grade);
+            writer.Write((byte)Grade);
 		}
     }
     public sealed class ObjectGold : Packet

--- a/ServerPackets.cs
+++ b/ServerPackets.cs
@@ -414,6 +414,7 @@ namespace ServerPackets
         public LightSetting Lights;
         public bool Lightning, Fire;
         public byte MapDarkLight;
+        public List<MapEventClientSide> MapEvents = new List<MapEventClientSide>();
 
         protected override void ReadPacket(BinaryReader reader)
         {
@@ -427,6 +428,10 @@ namespace ServerPackets
             if ((bools & 0x02) == 0x02) Fire = true;
             MapDarkLight = reader.ReadByte();
             Music = reader.ReadUInt16();
+
+            int count = reader.ReadInt32();
+            for (int i = 0; i < count; i++)
+                MapEvents.Add(new MapEventClientSide(reader));
         }
 
         protected override void WritePacket(BinaryWriter writer)
@@ -442,6 +447,10 @@ namespace ServerPackets
             writer.Write(bools);
             writer.Write(MapDarkLight);
             writer.Write(Music);
+
+            writer.Write(MapEvents.Count);
+            foreach (var mapEvent in MapEvents)
+                mapEvent.Save(writer);
         }
     }
     public sealed class UserInformation : Packet
@@ -2506,6 +2515,7 @@ namespace ServerPackets
         public Point Location;
         public MirDirection Direction;
         public byte MapDarkLight;
+        public List<MapEventClientSide> MapEvents = new List<MapEventClientSide>();
 
 
         protected override void ReadPacket(BinaryReader reader)
@@ -2519,6 +2529,10 @@ namespace ServerPackets
             Direction = (MirDirection)reader.ReadByte();
             MapDarkLight = reader.ReadByte();
             Music = reader.ReadUInt16();
+
+            int count = reader.ReadInt32();
+            for (int i = 0; i < count; i++)
+                MapEvents.Add(new MapEventClientSide(reader));
         }
         protected override void WritePacket(BinaryWriter writer)
         {
@@ -2532,6 +2546,10 @@ namespace ServerPackets
             writer.Write((byte)Direction);
             writer.Write(MapDarkLight);
             writer.Write(Music);
+
+            writer.Write(MapEvents.Count);
+            foreach (var mapEvent in MapEvents)
+                mapEvent.Save(writer);
         }
     }
     public sealed class ObjectTeleportOut : Packet
@@ -5645,6 +5663,92 @@ namespace ServerPackets
         protected override void WritePacket(BinaryWriter writer)
         {
             writer.Write(Success);
+        }
+    }
+    public sealed class EnterOrUpdatePublicEvent : Packet
+    {
+        public override short Index { get { return (short)ServerPacketIds.EnterPublicEvent; } }
+
+        public string EventName = string.Empty;
+        public string Objective = string.Empty;
+        public int CompletedPercentage = 0;
+        public string RemainingCount = string.Empty;
+        public int Stage = 0;
+        public EnterOrUpdatePublicEvent()
+        {
+
+        }
+        public EnterOrUpdatePublicEvent(string eventName, string objective, string remainingCount, int completedPercentage, int stage)
+        {
+            EventName = eventName;
+            Objective = objective;
+            RemainingCount = remainingCount;
+            Stage = stage;
+            CompletedPercentage = completedPercentage;
+        }
+        protected override void ReadPacket(BinaryReader reader)
+        {
+            EventName = reader.ReadString();
+            Objective = reader.ReadString();
+            RemainingCount = reader.ReadString();
+            CompletedPercentage = reader.ReadInt32();
+            Stage = reader.ReadInt32();
+        }
+        protected override void WritePacket(BinaryWriter writer)
+        {
+            writer.Write(EventName);
+            writer.Write(Objective);
+            writer.Write(RemainingCount);
+            writer.Write(CompletedPercentage);
+            writer.Write(Stage);
+        }
+    }
+    public sealed class LeavePublicEvent : Packet
+    {
+        public override short Index { get { return (short)ServerPacketIds.LeavePublicEvent; } }
+
+        public string EventName;
+
+        protected override void ReadPacket(BinaryReader reader)
+        {
+            EventName = reader.ReadString();
+
+        }
+        protected override void WritePacket(BinaryWriter writer)
+        {
+            writer.Write(EventName);
+        }
+    }
+    public sealed class ActivateEvent : Packet
+    {
+        public MapEventClientSide Event;
+        public override short Index
+        {
+            get { return (short)ServerPacketIds.ActivateEvent; }
+        }
+        protected override void ReadPacket(BinaryReader reader)
+        {
+            Event = new MapEventClientSide(reader);
+        }
+        protected override void WritePacket(BinaryWriter writer)
+        {
+            Event.Save(writer);
+        }
+    }
+    public sealed class DeactivateEvent : Packet
+    {
+        public MapEventClientSide Event;
+        public override short Index
+        {
+            get { return (short)ServerPacketIds.DeactivateEvent; }
+        }
+        protected override void ReadPacket(BinaryReader reader)
+        {
+            Event = new MapEventClientSide(reader);
+        }
+        protected override void WritePacket(BinaryWriter writer)
+        {
+            Event.Save(writer);
         }
     }
 }


### PR DESCRIPTION
Server
Database Impact/Changes
- Upped CustomVersion to 1. (Any of the below changes gets read if custom version >= 1 , if your using your own customversion it may conflict)
- New Field MapEventIndex (Gets Saved with Main DB File)
- New Field to MapInfo List<PublicEventInfo>
- 2 New fields to CharacterInfo (DailyEventsCompleted,WeeklyEventsCompleted)
- New DB File (Server.MirRTVDB) used to store and read runtime values such as (CurrentWeekOfTheYear,CurrentDayOfTheYear)

Logic Impact/Changes
- Map Now holds List<Events> and events gets processed within map process (Responsible of activating events)
- New Logic (MapEvent) - Events logic , deactivation,personal loot etc
- RespawnInfo - Added a new field IsEventObjective only used in runtime doesn't get saved/loaded, it gets set from Events logic when activating/spawning monsters
- MonsterObject Monsters in general will act different if its respawn is EventObjective (Events logic retreat,register contributors to event etc)
- PlayerObject Walk,Run should detect if you moved into an event and it will send you a packet to display the event dialog, Server Packets GetMapInformation & MapChanged now holds List<MapEventClientSide> to display events in the client
- Envir On server boot and every one hour server runs checks to clear players daily & weekly completed events (You can add currencies there aswell if your files has extra currencies like paragon mir and you want to implement some sort of a cap)

Client
- New field to MapControl (List<MapEventClientSide>) it gets cleared and refilled when MapChanged/MapInformation packets are receive.
- New Dialog Event Dialog Appears when you enter an event (Shows progress of the current event)
- BigMapDialog Displays List<MirControlImage> within on-draw event, it represents current map events, it uses Items.Lib, each event type choses a different image you can customize this based on your needs.