### PR TITLE
fixed bug.  filename error

### DIFF
--- a/LibraryEditor/MLibrary.cs
+++ b/LibraryEditor/MLibrary.cs
@@ -133,8 +133,7 @@ namespace LibraryEditor
         {
             string fileName = Path.ChangeExtension(FileName, ".Lib");
 
-            string file = Path.GetFileNameWithoutExtension(fileName);
-            fileName = fileName.Replace(file, file + "-converted");
+            fileName = fileName.Replace(".Lib", "-converted.Lib");
 
             if (File.Exists(fileName))
                 File.Delete(fileName);


### PR DESCRIPTION
when I convert the file that  named  "D:\mywork2018\client-040817\Data\MonkArmour\01.Lib"
the filename will be "D:\mywork201-converted8\client-040817\Data\MonkArmour\01-converted.Lib"。

it replace 01 twice.