### PR TITLE
Sockets

### DIFF
--- a/Client/MirObjects/UserObject.cs
+++ b/Client/MirObjects/UserObject.cs
@@ -318,6 +318,34 @@ namespace Client.MirObjects
                 ASpeed = (sbyte)Math.Max(sbyte.MinValue, (Math.Min(sbyte.MaxValue, ASpeed + temp.AttackSpeed + RealItem.AttackSpeed)));
                 Luck = (sbyte)Math.Max(sbyte.MinValue, (Math.Min(sbyte.MaxValue, Luck + temp.Luck + RealItem.Luck)));
 
+                for (int si = 0; si < temp.socketCount; si++)
+                {
+                    ItemInfo sockInfo = temp.sockets[si];
+
+                    if (sockInfo == null) continue;
+
+                    MinAC = (ushort)Math.Min(ushort.MaxValue, MinAC + sockInfo.MinAC);
+                    MaxAC = (ushort)Math.Min(ushort.MaxValue, MaxAC + sockInfo.MaxAC);
+                    MinMAC = (ushort)Math.Min(ushort.MaxValue, MinMAC + sockInfo.MinMAC);
+                    MaxMAC = (ushort)Math.Min(ushort.MaxValue, MaxMAC + sockInfo.MaxMAC);
+
+                    MinDC = (ushort)Math.Min(ushort.MaxValue, MinDC + sockInfo.MinDC);
+                    MaxDC = (ushort)Math.Min(ushort.MaxValue, MaxDC + sockInfo.MaxDC);
+                    MinMC = (ushort)Math.Min(ushort.MaxValue, MinMC + sockInfo.MinMC);
+                    MaxMC = (ushort)Math.Min(ushort.MaxValue, MaxMC + sockInfo.MaxMC);
+                    MinSC = (ushort)Math.Min(ushort.MaxValue, MinSC + sockInfo.MinSC);
+                    MaxSC = (ushort)Math.Min(ushort.MaxValue, MaxSC + sockInfo.MaxSC);
+
+                    Accuracy = (byte)Math.Min(byte.MaxValue, Accuracy + sockInfo.Accuracy);
+                    Agility = (byte)Math.Min(byte.MaxValue, Agility + sockInfo.Agility);
+
+                    MaxHP = (ushort)Math.Min(ushort.MaxValue, MaxHP + sockInfo.HP);
+                    MaxMP = (ushort)Math.Min(ushort.MaxValue, MaxMP + sockInfo.MP);
+
+                    ASpeed = (sbyte)Math.Max(sbyte.MinValue, (Math.Min(sbyte.MaxValue, ASpeed + sockInfo.AttackSpeed)));
+                    Luck = (sbyte)Math.Max(sbyte.MinValue, (Math.Min(sbyte.MaxValue, Luck + sockInfo.Luck)));
+                }
+
                 MaxBagWeight = (ushort)Math.Max(ushort.MinValue, (Math.Min(ushort.MaxValue, MaxBagWeight + RealItem.BagWeight)));
                 MaxWearWeight = (ushort)Math.Max(ushort.MinValue, (Math.Min(ushort.MaxValue, MaxWearWeight + RealItem.WearWeight)));
                 MaxHandWeight = (ushort)Math.Max(ushort.MinValue, (Math.Min(ushort.MaxValue, MaxHandWeight + RealItem.HandWeight)));

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -6837,7 +6837,7 @@ namespace Client.MirScenes
             ItemLabel.Size = new Size(ItemLabel.Size.Width, ItemLabel.Size.Height + 4);
             int count = 0;
 
-            #region AWAKENAMEF
+            #region AWAKENAME
             if (HoverItem.Awake.getAwakeLevel() > 0)
             {
                 count++;

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -3495,8 +3495,9 @@ namespace Client.MirScenes
             item.PoisonResist = p.Item.PoisonResist;
             item.RefinedValue = p.Item.RefinedValue;
             item.RefineAdded = p.Item.RefineAdded;
-            
 
+            item.sockets = p.Item.sockets;
+            
             GameScene.Scene.InventoryDialog.DisplayItemGridEffect(item.UniqueID, 0);
 
             //MirAnimatedControl anim = new MirAnimatedControl
@@ -5551,6 +5552,8 @@ namespace Client.MirScenes
                         break;
                     case ItemType.Gem:
                         break;
+                    case ItemType.Rune:
+                        break;
                     case ItemType.Potion:
                         break;
                     case ItemType.Transform:
@@ -6761,6 +6764,69 @@ namespace Client.MirScenes
             }
             return null;
         }
+        public MirControl socketInfoLabel(UserItem item, bool Inspect = false)
+        {
+            ushort level = Inspect ? InspectDialog.Level : MapObject.User.Level;
+            MirClass job = Inspect ? InspectDialog.Class : MapObject.User.Class;
+            HoverItem = item;
+            ItemInfo realItem = Functions.GetRealItem(item.Info, level, job, ItemInfoList);
+
+            ItemLabel.Size = new Size(ItemLabel.Size.Width, ItemLabel.Size.Height + 4);
+            int count = 0;
+
+
+            //SOCKETS
+            if (HoverItem.socketCount > 0) count++;
+            for (int i = 0; i < HoverItem.socketCount; i++)
+            {
+                Point l = new Point(5, ItemLabel.DisplayRectangle.Bottom + (i > 0 ? 2 : 3));
+                MirImageControl socketImg = new MirImageControl
+                {
+                    Size = new Size(2, 2),
+                    Index = item.sockets[i] != null ? item.sockets[i].Image : 2447,
+                    Library = Libraries.Prguse,
+                    Location = l,
+                    Parent = ItemLabel
+                };
+                ItemLabel.Size = new Size(ItemLabel.Size.Width, ItemLabel.Size.Height + 20);
+
+                MirLabel imgLbl = new MirLabel
+                {
+                    AutoSize = true,
+                    Location = new Point(20, socketImg.Location.Y),
+                    OutLine = true,
+                    Parent = ItemLabel,
+                    Text = (item.sockets[i] == null ? "Empty Socket" : item.sockets[i].FriendlyName)
+                };
+            }
+
+            if (count > 0)
+            {
+                ItemLabel.Size = new Size(ItemLabel.Size.Width, ItemLabel.Size.Height + 4);
+
+                #region OUTLINE
+                MirControl outLine = new MirControl
+                {
+                    BackColour = Color.FromArgb(255, 50, 50, 50),
+                    Border = true,
+                    BorderColour = Color.Gray,
+                    NotControl = true,
+                    Parent = ItemLabel,
+                    Opacity = 0.4F,
+                    Location = new Point(0, 0)
+                };
+                outLine.Size = ItemLabel.Size;
+                #endregion
+
+                return outLine;
+            }
+            else
+            {
+                ItemLabel.Size = new Size(ItemLabel.Size.Width, ItemLabel.Size.Height - 4);
+            }
+            return null;
+        }
+
         public MirControl AwakeInfoLabel(UserItem item, bool Inspect = false)
         {
             ushort level = Inspect ? InspectDialog.Level : MapObject.User.Level;
@@ -6769,10 +6835,9 @@ namespace Client.MirScenes
             ItemInfo realItem = Functions.GetRealItem(item.Info, level, job, ItemInfoList);
 
             ItemLabel.Size = new Size(ItemLabel.Size.Width, ItemLabel.Size.Height + 4);
-
             int count = 0;
 
-            #region AWAKENAME
+            #region AWAKENAMEF
             if (HoverItem.Awake.getAwakeLevel() > 0)
             {
                 count++;
@@ -7914,7 +7979,7 @@ namespace Client.MirScenes
             };
 
             //Name Info Label
-            MirControl[] outlines = new MirControl[9];
+            MirControl[] outlines = new MirControl[10];
             outlines[0] = NameInfoLabel(item, Inspect);
             //Attribute Info1 Label - Attack Info
             outlines[1] = AttackInfoLabel(item, Inspect);
@@ -7922,16 +7987,18 @@ namespace Client.MirScenes
             outlines[2] = DefenceInfoLabel(item, Inspect);
             //Attribute Info3 Label - Weight Info
             outlines[3] = WeightInfoLabel(item, Inspect);
+            //Socket Info Label
+            outlines[4] = socketInfoLabel(item, Inspect);
             //Awake Info Label
-            outlines[4] = AwakeInfoLabel(item, Inspect);
+            outlines[5] = AwakeInfoLabel(item, Inspect);
             //need Info Label
-            outlines[5] = NeedInfoLabel(item, Inspect);
+            outlines[6] = NeedInfoLabel(item, Inspect);
             //Bind Info Label
-            outlines[6] = BindInfoLabel(item, Inspect);
+            outlines[7] = BindInfoLabel(item, Inspect);
             //Overlap Info Label
-            outlines[7] = OverlapInfoLabel(item, Inspect);
+            outlines[8] = OverlapInfoLabel(item, Inspect);
             //Story Label
-            outlines[8] = StoryInfoLabel(item, Inspect);
+            outlines[9] = StoryInfoLabel(item, Inspect);
 
             foreach (var outline in outlines)
             {

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -7760,12 +7760,11 @@ namespace Client.MirScenes
 
             int count = 0;
 
+            #region CombineItemLabel
 
-            #region GEM
-
-            if (realItem.Type == ItemType.Gem)
+            if (realItem.Type == ItemType.Gem || realItem.Type == ItemType.Rune)
             {
-                string text = "";
+                string text = "Hold CTRL and left click to combine with an item.";
 
                 switch (realItem.Shape)
                 {
@@ -7775,13 +7774,9 @@ namespace Client.MirScenes
                     case 2:
                         text = "Hold CTRL and left click to repair armour\nand accessory items.";
                         break;
-                    case 3:
-                    case 4:
-                        text = "Hold CTRL and left click to combine with an item.";
-                        break;
                 }
                 count++;
-                MirLabel GEMLabel = new MirLabel
+                MirLabel CombineLabel = new MirLabel
                 {
                     AutoSize = true,
                     ForeColour = Color.White,
@@ -7791,8 +7786,8 @@ namespace Client.MirScenes
                     Text = text
                 };
 
-                ItemLabel.Size = new Size(Math.Max(ItemLabel.Size.Width, GEMLabel.DisplayRectangle.Right + 4),
-                    Math.Max(ItemLabel.Size.Height, GEMLabel.DisplayRectangle.Bottom));
+                ItemLabel.Size = new Size(Math.Max(ItemLabel.Size.Width, CombineLabel.DisplayRectangle.Right + 4),
+                    Math.Max(ItemLabel.Size.Height, CombineLabel.DisplayRectangle.Bottom));
             }
 
             #endregion

--- a/Common.cs
+++ b/Common.cs
@@ -3024,7 +3024,7 @@ public class UserItem
         get
         {
             return AC != 0 || MAC != 0 || DC != 0 || MC != 0 || SC != 0 || Accuracy != 0 || Agility != 0 || HP != 0 || MP != 0 || AttackSpeed != 0 || Luck != 0 || Strong != 0 || MagicResist != 0 || PoisonResist != 0 ||
-                HealthRecovery != 0 || ManaRecovery != 0 || PoisonRecovery != 0 || CriticalRate != 0 || CriticalDamage != 0 || Freezing != 0 || PoisonAttack != 0;
+                HealthRecovery != 0 || ManaRecovery != 0 || PoisonRecovery != 0 || CriticalRate != 0 || CriticalDamage != 0 || Freezing != 0 || PoisonAttack != 0 || socketCount != 0;
         }
     }
 

--- a/Common.cs
+++ b/Common.cs
@@ -5440,6 +5440,7 @@ public class RandomItemStat
     public byte CriticalRateChance, CriticalRateStatChance, CriticalRateMaxStat, CriticalDamageChance, CriticalDamageStatChance, CriticalDamageMaxStat;
     public byte FreezeChance, FreezeStatChance, FreezeMaxStat, PoisonAttackChance, PoisonAttackStatChance, PoisonAttackMaxStat;
     public byte AttackSpeedChance, AttackSpeedStatChance, AttackSpeedMaxStat, LuckChance, LuckStatChance, LuckMaxStat;
+    public byte SocketChance, SocketMaxStat, SocketStatChance;
     public byte CurseChance;
 
     public RandomItemStat(ItemType Type = ItemType.Book)
@@ -5503,6 +5504,10 @@ public class RandomItemStat
         AccuracyChance = 30;
         AccuracyStatChance = 20;
         AccuracyMaxStat = 2;
+
+        SocketChance = 50;
+        SocketStatChance = 30;
+        SocketMaxStat = 3;
     }
     public void SetArmour()
     {
@@ -5530,6 +5535,10 @@ public class RandomItemStat
         MaxScStatChance = 20;
         MaxScMaxStat = 7;
 
+        SocketChance = 50;
+        SocketStatChance = 30;
+        SocketMaxStat = 3;
+
     }
     public void SetHelmet()
     {
@@ -5556,6 +5565,10 @@ public class RandomItemStat
         MaxScChance = 40;
         MaxScStatChance = 20;
         MaxScMaxStat = 7;
+
+        SocketChance = 80;
+        SocketStatChance = 50;
+        SocketMaxStat = 2;
     }
     public void SetBeltBoots()
     {
@@ -5586,6 +5599,10 @@ public class RandomItemStat
         AgilityChance = 60;
         AgilityStatChance = 30;
         AgilityMaxStat = 3;
+
+        SocketChance = 80;
+        SocketStatChance = 50;
+        SocketMaxStat = 2;
     }
     public void SetNecklace()
     {
@@ -5612,6 +5629,10 @@ public class RandomItemStat
         AgilityChance = 60;
         AgilityStatChance = 30;
         AgilityMaxStat = 7;
+
+        SocketChance = 50;
+        SocketStatChance = 30;
+        SocketMaxStat = 3;
     }
     public void SetBracelet()
     {
@@ -5638,6 +5659,10 @@ public class RandomItemStat
         MaxScChance = 30;
         MaxScStatChance = 30;
         MaxScMaxStat = 6;
+
+        SocketChance = 50;
+        SocketStatChance = 30;
+        SocketMaxStat = 3;
     }
     public void SetRing()
     {
@@ -5664,6 +5689,10 @@ public class RandomItemStat
         MaxScChance = 15;
         MaxScStatChance = 30;
         MaxScMaxStat = 6;
+
+        SocketChance = 50;
+        SocketStatChance = 30;
+        SocketMaxStat = 3;
     }
 
     public void SetMount()

--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -55,7 +55,7 @@ namespace Server.MirEnvir
         public static object AccountLock = new object();
         public static object LoadLock = new object();
 
-        public const int Version = 77;
+        public const int Version = 78;
         public const int CustomVersion = 0;
         public const string DatabasePath = @".\Server.MirDB";
         public const string AccountPath = @".\Server.MirADB";

--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -2645,6 +2645,7 @@ namespace Server.MirEnvir
             if ((stat.PoisonAttackChance > 0) && (Random.Next(stat.PoisonAttackChance) == 0)) item.PoisonAttack = (byte)(RandomomRange(stat.PoisonAttackMaxStat-1, stat.PoisonAttackStatChance)+1);
             if ((stat.AttackSpeedChance > 0) && (Random.Next(stat.AttackSpeedChance) == 0)) item.AttackSpeed = (sbyte)(RandomomRange(stat.AttackSpeedMaxStat-1, stat.AttackSpeedStatChance)+1);
             if ((stat.LuckChance > 0) && (Random.Next(stat.LuckChance) == 0)) item.Luck = (sbyte)(RandomomRange(stat.LuckMaxStat-1, stat.LuckStatChance)+1);
+            if ((stat.SocketChance > 0) && (Random.Next(stat.SocketChance) == 0)) item.socketCount = (sbyte)(RandomomRange(Math.Min((byte)3, stat.SocketMaxStat) - 1, stat.SocketStatChance) + 1);
             if ((stat.CurseChance > 0) && (Random.Next(100) <= stat.CurseChance)) item.Cursed = true;
         }
 

--- a/Server/MirForms/BalanceConfigForm.Designer.cs
+++ b/Server/MirForms/BalanceConfigForm.Designer.cs
@@ -214,6 +214,10 @@
             this.RISMaxDuraChancetextBox = new System.Windows.Forms.TextBox();
             this.label40 = new System.Windows.Forms.Label();
             this.RISIndexcomboBox = new System.Windows.Forms.ComboBox();
+            this.RISSocketChancetextBox = new System.Windows.Forms.TextBox();
+            this.RISSocketStatChancetextBox = new System.Windows.Forms.TextBox();
+            this.RISSocketMaxStattextBox = new System.Windows.Forms.TextBox();
+            this.label64 = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -378,7 +382,7 @@
             this.tabControl1.Location = new System.Drawing.Point(12, 12);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(632, 689);
+            this.tabControl1.Size = new System.Drawing.Size(632, 738);
             this.tabControl1.TabIndex = 16;
             // 
             // tabPage1
@@ -1114,7 +1118,7 @@
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(624, 663);
+            this.tabPage4.Size = new System.Drawing.Size(624, 712);
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "Random Item Stats";
             this.tabPage4.UseVisualStyleBackColor = true;
@@ -1141,6 +1145,7 @@
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.label64);
             this.groupBox3.Controls.Add(this.RISCurseChancetextBox);
             this.groupBox3.Controls.Add(this.label63);
             this.groupBox3.Controls.Add(this.label62);
@@ -1170,14 +1175,14 @@
             this.groupBox3.Controls.Add(this.groupBox4);
             this.groupBox3.Location = new System.Drawing.Point(6, 30);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(600, 630);
+            this.groupBox3.Size = new System.Drawing.Size(600, 686);
             this.groupBox3.TabIndex = 9;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Random settings";
             // 
             // RISCurseChancetextBox
             // 
-            this.RISCurseChancetextBox.Location = new System.Drawing.Point(88, 607);
+            this.RISCurseChancetextBox.Location = new System.Drawing.Point(542, 39);
             this.RISCurseChancetextBox.MaxLength = 3;
             this.RISCurseChancetextBox.Name = "RISCurseChancetextBox";
             this.RISCurseChancetextBox.Size = new System.Drawing.Size(38, 20);
@@ -1187,7 +1192,7 @@
             // label63
             // 
             this.label63.AutoSize = true;
-            this.label63.Location = new System.Drawing.Point(6, 610);
+            this.label63.Location = new System.Drawing.Point(460, 42);
             this.label63.Name = "label63";
             this.label63.Size = new System.Drawing.Size(76, 13);
             this.label63.TabIndex = 39;
@@ -1393,6 +1398,7 @@
             // 
             // groupBox6
             // 
+            this.groupBox6.Controls.Add(this.RISSocketMaxStattextBox);
             this.groupBox6.Controls.Add(this.RISLuckMaxStattextBox);
             this.groupBox6.Controls.Add(this.RISAttackSpeedMaxStattextBox);
             this.groupBox6.Controls.Add(this.RISPoisonAttackMaxStattextBox);
@@ -1417,7 +1423,7 @@
             this.groupBox6.Controls.Add(this.RISMaxDuraMaxStattextBox);
             this.groupBox6.Location = new System.Drawing.Point(347, 19);
             this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Size = new System.Drawing.Size(95, 592);
+            this.groupBox6.Size = new System.Drawing.Size(95, 628);
             this.groupBox6.TabIndex = 3;
             this.groupBox6.TabStop = false;
             this.groupBox6.Text = "Maximum Stats";
@@ -1622,6 +1628,7 @@
             // 
             // groupBox5
             // 
+            this.groupBox5.Controls.Add(this.RISSocketStatChancetextBox);
             this.groupBox5.Controls.Add(this.RISLuckStatChancetextBox);
             this.groupBox5.Controls.Add(this.RISMaxDuraStatChancetextBox);
             this.groupBox5.Controls.Add(this.RISAttackSpeedStatChancetextBox);
@@ -1646,7 +1653,7 @@
             this.groupBox5.Controls.Add(this.RISStrongStatChancetextBox);
             this.groupBox5.Location = new System.Drawing.Point(256, 19);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(85, 592);
+            this.groupBox5.Size = new System.Drawing.Size(85, 628);
             this.groupBox5.TabIndex = 2;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "Chance/Stat";
@@ -1851,6 +1858,7 @@
             // 
             // groupBox4
             // 
+            this.groupBox4.Controls.Add(this.RISSocketChancetextBox);
             this.groupBox4.Controls.Add(this.RISLuckChancetextBox);
             this.groupBox4.Controls.Add(this.RISAttackSpeedChancetextBox);
             this.groupBox4.Controls.Add(this.RISPoisonAttackChancetextBox);
@@ -1875,7 +1883,7 @@
             this.groupBox4.Controls.Add(this.RISMaxDuraChancetextBox);
             this.groupBox4.Location = new System.Drawing.Point(144, 19);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(106, 592);
+            this.groupBox4.Size = new System.Drawing.Size(106, 628);
             this.groupBox4.TabIndex = 1;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Random chance:";
@@ -2097,11 +2105,44 @@
             this.RISIndexcomboBox.TabIndex = 7;
             this.RISIndexcomboBox.SelectedIndexChanged += new System.EventHandler(this.RISIndexcomboBox_SelectedIndexChanged);
             // 
+            // RISSocketChancetextBox
+            // 
+            this.RISSocketChancetextBox.Location = new System.Drawing.Point(32, 592);
+            this.RISSocketChancetextBox.MaxLength = 3;
+            this.RISSocketChancetextBox.Name = "RISSocketChancetextBox";
+            this.RISSocketChancetextBox.Size = new System.Drawing.Size(38, 20);
+            this.RISSocketChancetextBox.TabIndex = 31;
+            // 
+            // RISSocketStatChancetextBox
+            // 
+            this.RISSocketStatChancetextBox.Location = new System.Drawing.Point(24, 592);
+            this.RISSocketStatChancetextBox.MaxLength = 3;
+            this.RISSocketStatChancetextBox.Name = "RISSocketStatChancetextBox";
+            this.RISSocketStatChancetextBox.Size = new System.Drawing.Size(38, 20);
+            this.RISSocketStatChancetextBox.TabIndex = 53;
+            // 
+            // RISSocketMaxStattextBox
+            // 
+            this.RISSocketMaxStattextBox.Location = new System.Drawing.Point(21, 592);
+            this.RISSocketMaxStattextBox.MaxLength = 3;
+            this.RISSocketMaxStattextBox.Name = "RISSocketMaxStattextBox";
+            this.RISSocketMaxStattextBox.Size = new System.Drawing.Size(38, 20);
+            this.RISSocketMaxStattextBox.TabIndex = 53;
+            // 
+            // label64
+            // 
+            this.label64.AutoSize = true;
+            this.label64.Location = new System.Drawing.Point(6, 618);
+            this.label64.Name = "label64";
+            this.label64.Size = new System.Drawing.Size(46, 13);
+            this.label64.TabIndex = 40;
+            this.label64.Text = "Sockets";
+            // 
             // BalanceConfigForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(653, 705);
+            this.ClientSize = new System.Drawing.Size(653, 762);
             this.Controls.Add(this.tabControl1);
             this.Name = "BalanceConfigForm";
             this.Text = "BalanceConfigForm";
@@ -2316,5 +2357,9 @@
         private System.Windows.Forms.Button RISAddIndexbutton;
         private System.Windows.Forms.TextBox RISCurseChancetextBox;
         private System.Windows.Forms.Label label63;
+        private System.Windows.Forms.Label label64;
+        private System.Windows.Forms.TextBox RISSocketMaxStattextBox;
+        private System.Windows.Forms.TextBox RISSocketStatChancetextBox;
+        private System.Windows.Forms.TextBox RISSocketChancetextBox;
     }
 }

--- a/Server/MirForms/BalanceConfigForm.cs
+++ b/Server/MirForms/BalanceConfigForm.cs
@@ -207,6 +207,9 @@ namespace Server
                 RISLuckChancetextBox.Text = string.Empty;
                 RISLuckStatChancetextBox.Text = string.Empty;
                 RISLuckMaxStattextBox.Text = string.Empty;
+                RISSocketChancetextBox.Text = string.Empty;
+                RISSocketMaxStattextBox.Text = string.Empty;
+                RISSocketStatChancetextBox.Text = string.Empty;
                 RISCurseChancetextBox.Text = string.Empty;
             }
             else
@@ -284,6 +287,9 @@ namespace Server
                 RISLuckChancetextBox.Text = stat.LuckChance.ToString();
                 RISLuckStatChancetextBox.Text = stat.LuckStatChance.ToString();
                 RISLuckMaxStattextBox.Text = stat.LuckMaxStat.ToString();
+                RISSocketChancetextBox.Text = stat.SocketChance.ToString();
+                RISSocketMaxStattextBox.Text = stat.SocketMaxStat.ToString();
+                RISSocketStatChancetextBox.Text = stat.SocketStatChance.ToString();
                 RISCurseChancetextBox.Text = stat.CurseChance.ToString();
             }
         }

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -11879,30 +11879,33 @@ namespace Server.MirObjects
                 return;
             }
 
-            switch (tempFrom.Info.Shape)
-            {
-                case 7: //Rune
-                    if (tempTo.socketCount < 1)
-                    {
-                        ReceiveChat("Item has no slots.", ChatType.Hint);
-                        return;
-                    } 
 
-                    for (int i = 0; i < tempTo.socketCount; i++)
+            if (tempFrom.Info.Type == ItemType.Rune)
+            {
+                if (tempTo.socketCount < 1)
+                {
+                    ReceiveChat("Item has no slots.", ChatType.Hint);
+                    return;
+                }
+
+                for (int i = 0; i < tempTo.socketCount; i++)
+                {
+                    if (tempTo.sockets[i] == null)
                     {
-                        if (tempTo.sockets[i] == null)
-                        {
-                            tempTo.sockets[i] = tempFrom.Info;
-                            slotLoc = i;
-                            break;
-                        }
-                        else if (i == tempTo.socketCount - 1)
-                        {
-                            ReceiveChat("Item has no available slots.", ChatType.Hint);
-                            continue;
-                        }
+                        tempTo.sockets[i] = tempFrom.Info;
+                        slotLoc = i;
+                        break;
                     }
-                    break;
+                    else if (i == tempTo.socketCount - 1)
+                    {
+                        ReceiveChat("Item has no available slots.", ChatType.Hint);
+                        continue;
+                    }
+                }
+            }
+            else if (tempFrom.Info.Type == ItemType.Gem)
+            switch (tempFrom.Info.Shape)
+            {  
                 case 1: //BoneHammer
                 case 2: //SewingSupplies
                 case 5: //SpecialHammer

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -4392,18 +4392,27 @@ namespace Server.MirObjects
                         SMain.Enqueue(string.Format("Player {0} has been given {1} gold", player.Name, count));
                         break;
 
-                    case "IWS":
+                    case "ADDSOCKET":
                         if (!IsGM) return;
 
-                        if (this.Info.Equipment[0] != null)
+                        if ((!IsGM && !Settings.TestServer) || parts.Length < 1) return;
+
+                        int equipSlot = int.Parse(parts[1]);
+                        if (equipSlot < 0 || equipSlot > 11) return;
+
+                        UserItem xitem = this.Info.Equipment[int.Parse(parts[1])];
+                        if (xitem != null && xitem.socketCount < xitem.sockets.Length)
                         {
-                            UserItem xwep = this.Info.Equipment[0];
-                            xwep.socketCount++;
-                            Enqueue(new S.RefreshItem { Item = this.Info.Equipment[0] });
-                            SMain.Enqueue(string.Format("Upgraded {0} with an extra socket.", this.Info.Equipment[0].FriendlyName));
+                            xitem.socketCount++;
+                            Enqueue(new S.RefreshItem { Item = xitem });
+
+                            String outMsg = string.Format("Upgraded {0} with an extra socket.", xitem.FriendlyName);
+
+                            this.ReceiveChat(outMsg, ChatType.System);
+                            SMain.Enqueue(outMsg);
+                            return;
                         }
                         break;
-
                     case "GIVEPEARLS":
                         if ((!IsGM && !Settings.TestServer) || parts.Length < 2) return;
 

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -801,6 +801,9 @@ namespace Server
                 stat.LuckChance = reader.ReadByte("Item" + i.ToString(), "LuckChance", 0);
                 stat.LuckStatChance = reader.ReadByte("Item" + i.ToString(), "LuckStatChance", 1);
                 stat.LuckMaxStat = reader.ReadByte("Item" + i.ToString(), "LuckMaxStat", 1);
+                stat.SocketChance = reader.ReadByte("Item" + i.ToString(), "SocketChance", 0);
+                stat.SocketStatChance = reader.ReadByte("Item" + i.ToString(), "SocketStatChance", 1);
+                stat.SocketMaxStat = reader.ReadByte("Item" + i.ToString(), "SocketMaxStat", 1);
                 stat.CurseChance = reader.ReadByte("Item" + i.ToString(), "CurseChance", 0);
                 RandomItemStatsList.Add(stat);
                 i++;
@@ -880,6 +883,9 @@ namespace Server
                 reader.Write("Item" + i.ToString(), "LuckChance", stat.LuckChance);
                 reader.Write("Item" + i.ToString(), "LuckStatChance", stat.LuckStatChance);
                 reader.Write("Item" + i.ToString(), "LuckMaxStat", stat.LuckMaxStat);
+                reader.Write("Item" + i.ToString(), "SocketChance", stat.SocketChance);
+                reader.Write("Item" + i.ToString(), "SocketStatChance", stat.SocketStatChance);
+                reader.Write("Item" + i.ToString(), "SocketMaxStat", stat.SocketMaxStat);
                 reader.Write("Item" + i.ToString(), "CurseChance", stat.CurseChance);
             }
         }


### PR DESCRIPTION
Some tweaking still needed for GameScene.cs for loading images in. Images also need to be created / added. Recommended size for socket in item label is 15x15.

Sockets can be combined the same as Gems (CTRL + click into item with sockets)

Rune type is available in item database. User can enter stats into the item database and stats will be added to character accordingly. Made the decision to not display rune stats on item label due to it not being feasible to display all stats (if multiple are added) to a rune.

![image](https://user-images.githubusercontent.com/11903234/46893802-235db880-ce6a-11e8-9c48-0b7acf23300d.png)

~Need to add socket logic into RANDOMSTATS and then added to item drop logic accordingly.~
Sockets added to RIS, now will add sockets on @MAKE and through drops (needs to be configured).

![image](https://user-images.githubusercontent.com/11903234/46892802-92d1a900-ce66-11e8-88fc-045ff55ace47.png)
