### PR TITLE
Fixed empty name on the Export.

### DIFF
--- a/LibraryEditor/LMain.cs
+++ b/LibraryEditor/LMain.cs
@@ -38,7 +38,7 @@ namespace LibraryEditor
                 // Show .Lib path in application title.
                 FileInfo fileInfo = new FileInfo(Program.openFileWith);
                 this.Text = fileInfo.FullName.ToString();
-
+                OpenLibraryDialog.FileName = fileInfo.Name;
                 PreviewListView.SelectedIndices.Clear();
 
                 if (PreviewListView.Items.Count > 0)


### PR DESCRIPTION
Was an issue with Exporting images from a library opened direction from the .lib file.
Binary file updated.