### PR TITLE
TDB Poison moved from initial cast to CompleteAttack

### DIFF
--- a/Server/MirObjects/DelayedAction.cs
+++ b/Server/MirObjects/DelayedAction.cs
@@ -8,6 +8,9 @@ namespace Server.MirObjects
     public enum DelayedType
     {
         Magic,
+        /// <summary>
+        /// Param0 MapObject (Target) | Param1 Damage | Param2 Defence | Param3 damageWeapon | Param4 UserMagic | Param5 FinalHit
+        /// </summary>
         Damage,
         RangeDamage,
         Spawn,


### PR DESCRIPTION
The applying of TDB Poison (Stun) has been moved in order to prevent the Poison triggering even if you miss.
There are two additional parameters that can be used (I'm not sure what other spells have a double hit that lead to an effect on the second hit so I only did TDB)

Just be sure to set the parameters on the DelayedAction initialisation.

I've added a summary to the DelayedType.Damage to make it easier.

Suggest adding a new class or a struct to hold delayed attack information rather than using parameters for better control.


May I also suggest, verifying the target object is actually in the same location where the initial hit has taken place, this would effectively allow players to dodge melee attacks (as you use to on Euro)