### PR TITLE
Dropping gold disabled if NoDropMonster flag is set.

### DIFF
--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -748,6 +748,8 @@ namespace Server.MirObjects
 
         protected virtual void Drop()
         {
+            if (CurrentMap.Info.NoDropMonster)
+                return;
             for (int i = 0; i < Info.Drops.Count; i++)
             {
                 DropInfo drop = Info.Drops[i];


### PR DESCRIPTION
Prevent Gold from dropping from Monsters on maps with NoDropMonster flag set.