### PR TITLE
Bind mode exploit fix & Expire items in storage.

### DIFF
--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -2957,7 +2957,7 @@ namespace Client.MirScenes
                 if (item == null || item.UniqueID != p.UniqueID) continue;
 
                 if (item.Count == p.Count)
-                    User.Inventory[i] = null;
+                    Storage[i] = null;
                 else
                     item.Count -= p.Count;
                 break;

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -2951,7 +2951,17 @@ namespace Client.MirScenes
                     item.Count -= p.Count;
                 break;
             }
+            for (int i = 0; i < Storage.Length; i++)
+            {
+                var item = Storage[i];
+                if (item == null || item.UniqueID != p.UniqueID) continue;
 
+                if (item.Count == p.Count)
+                    User.Inventory[i] = null;
+                else
+                    item.Count -= p.Count;
+                break;
+            }
             User.RefreshStats();
         }
         private void Death(S.Death p)


### PR DESCRIPTION
Fixed exploit on DontStore flagged items while they're equipped from going into storage.

Expire items will also now be deleted from storage once expired.