### PR TITLE
Trade & Group request delays

### DIFF
--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -16,6 +16,9 @@ namespace Server.MirObjects
 {
     public sealed class PlayerObject : MapObject
     {
+        private long NextTradeTime;
+        private long NextGroupInviteTime;
+
         public string GMPassword = Settings.GMPassword;
         public bool IsGM, GMLogin, GMNeverDie, GMGameMaster, EnableGroupRecall, EnableGuildInvite, AllowMarriage, AllowLoverRecall, AllowMentor, HasMapShout, HasServerShout;
 
@@ -15286,6 +15289,8 @@ namespace Server.MirObjects
         }
         public void AddMember(string name)
         {
+            if (Envir.Time < NextGroupInviteTime) return;
+            NextGroupInviteTime = Envir.Time + Settings.GroupInviteDelay;
             if (GroupMembers != null && GroupMembers[0] != this)
             {
                 ReceiveChat("You are not the group leader.", ChatType.System);
@@ -16264,8 +16269,13 @@ namespace Server.MirObjects
             Enqueue(p);
         }
 
+        
+
         public void TradeRequest()
         {
+            if (Envir.Time < NextTradeTime) return;
+            NextTradeTime = Envir.Time + Settings.TradeDelay;
+
             if (TradePartner != null)
             {
                 ReceiveChat("You are already trading.", ChatType.System);

--- a/Server/Settings.cs
+++ b/Server/Settings.cs
@@ -256,6 +256,8 @@ namespace Server
         public static List<long> Guild_ExperienceList = new List<long>();
         public static List<int> Guild_MembercapList = new List<int>();
         public static List<GuildBuffInfo> Guild_BuffList = new List<GuildBuffInfo>();
+        public static long GroupInviteDelay { get; internal set; } = 2000;
+        public static long TradeDelay { get; internal set; } = 2000;
 
         public static void LoadVersion()
         {
@@ -360,6 +362,8 @@ namespace Server
             ToadName = Reader.ReadString("Game", "ToadName", ToadName);
             SnakeTotemName = Reader.ReadString("Game", "SnakeTotemName", SnakeTotemName);
             SnakesName = Reader.ReadString("Game", "SnakesName", SnakesName);
+            GroupInviteDelay = Reader.ReadInt64("Game", "GroupInviteDelay", GroupInviteDelay);
+            TradeDelay = Reader.ReadInt64("Game", "TradeDelay", TradeDelay);
 
             //Rested
             RestedPeriod = Reader.ReadInt32("Rested", "Period", RestedPeriod);
@@ -569,6 +573,8 @@ namespace Server
             Reader.Write("Game", "ToadName", ToadName);
             Reader.Write("Game", "SnakeTotemName", SnakeTotemName);
             Reader.Write("Game", "SnakesName", SnakesName);
+            Reader.Write("Game", "GroupInviteDelay", GroupInviteDelay);
+            Reader.Write("Game", "TradeDelay", TradeDelay);
 
             Reader.Write("Rested", "Period", RestedPeriod);
             Reader.Write("Rested", "BuffLength", RestedBuffLength);
@@ -585,7 +591,7 @@ namespace Server
 
             Reader.Write("DropGold", "DropGold", DropGold);
             Reader.Write("DropGold", "MaxDropGold", MaxDropGold);
-
+            
             Reader.Write("Items", "MaxMagicResist", MaxMagicResist);
             Reader.Write("Items", "MagicResistWeight", MagicResistWeight);
             Reader.Write("Items", "MaxPoisonResist", MaxPoisonResist);


### PR DESCRIPTION
Trade & Group request delays (prevent people spamming other people with requests)

Delay can be set by server owner using the Setup config file under the Game Section.

Really they (players) should be setting them to disabled but this will do for those who refuse to do so.