### PR TITLE
Fix bug on armour vs defence type.

### DIFF
--- a/Server/MirObjects/MapObject.cs
+++ b/Server/MirObjects/MapObject.cs
@@ -435,7 +435,7 @@ namespace Server.MirObjects
                         BroadcastDamageIndicator(DamageType.Miss);
                         hit = false;
                     }
-                    armour = GetDefencePower(MinAC, MaxAC);
+                    armour = GetDefencePower(MinMAC, MaxMAC);
                     break;
                 case DefenceType.Agility:
                     if (Envir.Random.Next(Agility + 1) > attacker.Accuracy)


### PR DESCRIPTION
This bug was originally fixed a while ago, it came back when I made the small refactor.
Targeted stat (MAC) is now set correctly for the MAC Defence Type.