### PR TITLE
Character Names crashing server

### DIFF
--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -2069,7 +2069,14 @@ namespace Server.MirEnvir
 
         private void Connection(IAsyncResult result)
         {
-            if (!Running || !_listener.Server.IsBound) return;
+            try
+            {
+                if (!Running || !_listener.Server.IsBound) return;
+            }
+            catch (Exception e)
+            {
+                SMain.Enqueue(e.ToString());
+            }
 
             try
             {

--- a/Server/MirEnvir/Reporting.cs
+++ b/Server/MirEnvir/Reporting.cs
@@ -39,7 +39,7 @@ namespace Server.MirEnvir
         {
             Player = player;
 
-            string baseDir = @Settings.ReportPath + player.Name;
+            string baseDir = @Settings.ReportPath + player.Name + "_player";
 
             try
             {

--- a/Server/MirEnvir/Reporting.cs
+++ b/Server/MirEnvir/Reporting.cs
@@ -18,6 +18,7 @@ namespace Server.MirEnvir
         //private int _traceDepth = 2;
         private int _saveCount = 200;
         private string _baseDir = "";
+        private readonly DateTime _startTime = DateTime.Now;
 
         #region Public Properties
 
@@ -38,10 +39,26 @@ namespace Server.MirEnvir
         {
             Player = player;
 
-            string baseDir = Settings.ReportPath + player.Name;
+            string baseDir = @Settings.ReportPath + player.Name;
 
-            if (!Directory.Exists(baseDir))
-                Directory.CreateDirectory(baseDir);
+            try
+            {
+                if (!Directory.Exists(baseDir))
+                    Directory.CreateDirectory(baseDir);
+            }
+            catch (Exception ex)
+            {
+                // Get stack trace for the exception with source file information
+                var st = new StackTrace(ex, true);
+                // Get the top stack frame
+                var frame = st.GetFrame(0);
+                // Get the line number from the stack frame
+                var line = frame.GetFileLineNumber();
+
+                SMain.Enqueue("Could not save player reporting");
+                File.AppendAllText(Settings.ErrorPath + "Error.txt",
+                string.Format("[{0}] {1} at line {2}{3}", DateTime.Now, ex, line, Environment.NewLine));
+            }
 
             _baseDir = baseDir;
         }
@@ -299,9 +316,26 @@ namespace Server.MirEnvir
             string filename = SMain.Envir.Now.Date.ToString(@"yyyy-MM-dd");
             string fullPath = _baseDir + @"\" + filename + ".txt";
 
-            if (!File.Exists(fullPath))
-                File.Create(fullPath).Close();
-            
+            try
+            {
+                if (!File.Exists(fullPath))
+                    File.Create(fullPath).Close();
+            }
+            catch (Exception ex)
+            {
+                // Get stack trace for the exception with source file information
+                var st = new StackTrace(ex, true);
+                // Get the top stack frame
+                var frame = st.GetFrame(0);
+                // Get the line number from the stack frame
+                var line = frame.GetFileLineNumber();
+
+                SMain.Enqueue("Could not save player reporting");
+                File.AppendAllText(Settings.ErrorPath + "Error.txt",
+                string.Format("[{0}] {1} at line {2}{3}", DateTime.Now, ex, line, Environment.NewLine));
+                return;
+            }
+
             for (int i = 0; i < Actions.Count; i++)
             {
                 Action action = Actions[i];
@@ -309,7 +343,25 @@ namespace Server.MirEnvir
                 string output = string.Format("{0:hh\\:mm\\:ss}, {1}, {2}, {3}, {4}" + Environment.NewLine,
                     action.Time, action.Player, action.Task, action.AddedInfo, action.Source);
 
-                File.AppendAllText(fullPath, output);
+                try
+                {
+                    File.AppendAllText(fullPath, output);
+                } 
+                catch (Exception ex)
+                {
+                    // Get stack trace for the exception with source file information
+                    var st = new StackTrace(ex, true);
+                    // Get the top stack frame
+                    var frame = st.GetFrame(0);
+                    // Get the line number from the stack frame
+                    var line = frame.GetFileLineNumber();
+
+                    SMain.Enqueue("Could not save player reporting");
+                    File.AppendAllText(Settings.ErrorPath + "Error.txt",
+                    string.Format("[{0}] {1} at line {2}{3}", DateTime.Now, ex, line, Environment.NewLine));
+                    break;
+                }
+                
             }
 
             Actions.Clear();


### PR DESCRIPTION
Character names outlined in #339 crashing server. 

This places a try/catch block around the `File.Create` and adds the exception to the error log in the normal way.