### PR TITLE
Stop Assassin clone attacking after explosion (die)

### DIFF
--- a/Server/MirObjects/Monsters/HumanAssassin.cs
+++ b/Server/MirObjects/Monsters/HumanAssassin.cs
@@ -246,7 +246,11 @@ namespace Server.MirObjects.Monsters
 
         protected override void Attack()
         {
-            if (AttackDamage >= 500) Die();
+            if (AttackDamage >= 500) 
+            {   
+                Die();
+                return;
+            }
 
             ShockTime = 0;
 


### PR DESCRIPTION
Assassin clone will no longer attempt to attack after exploding when reaching the desired damage (500 in this case)