### PR TITLE
Archer fix  ( and npc play sound action)

### DIFF
--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -1708,6 +1708,9 @@ namespace Client.MirScenes
                 case (short)ServerPacketIds.OpenBrowser:                  
                     OpenBrowser((S.OpenBrowser)p);
                     break;
+                case (short)ServerPacketIds.playSound:
+                    playThesound((S.playSound)p);
+                    break;
                 default:
                     base.ProcessPacket(p);
                     break;
@@ -8419,6 +8422,11 @@ namespace Client.MirScenes
 
         private void OpenBrowser(S.OpenBrowser p) {
             BrowserHelper.OpenDefaultBrowser(p.Url);
+        }
+
+        public void playThesound(S.playSound p)
+        {
+            SoundManager.PlaySound(p.sound, false);
         }
 
 

--- a/Common.cs
+++ b/Common.cs
@@ -1516,7 +1516,8 @@ public enum ServerPacketIds : short
     CanConfirmItemRental,
     ConfirmItemRental,
     NewRecipeInfo,
-    OpenBrowser
+    OpenBrowser,
+    playSound,
 }
 
 public enum ClientPacketIds : short
@@ -5302,6 +5303,8 @@ public abstract class Packet
                 return new S.NewRecipeInfo();
             case (short)ServerPacketIds.OpenBrowser:
                 return new S.OpenBrowser();
+            case (short)ServerPacketIds.playSound:
+                return new S.playSound();
             default:
                 return null;
         }

--- a/Server/MirObjects/NPC/NPCActions.cs
+++ b/Server/MirObjects/NPC/NPCActions.cs
@@ -99,5 +99,6 @@ namespace Server.MirObjects
         ClearGuildNameList,
         OpenBrowser,
         GetRandomText,
+        PlaySound,
     }
 }

--- a/Server/MirObjects/NPC/NPCSegment.cs
+++ b/Server/MirObjects/NPC/NPCSegment.cs
@@ -1044,6 +1044,12 @@ namespace Server.MirObjects
                     if (match.Success)
                         acts.Add(new NPCActions(ActionType.GetRandomText, parts[1], parts[2]));
                     break;
+                case "PLAYSOUND":
+
+                    if (parts.Length < 2) return;
+
+                    acts.Add(new NPCActions(ActionType.PlaySound, parts[1]));
+                    break;
             }
 
         }
@@ -3636,6 +3642,11 @@ namespace Server.MirObjects
                             string randomText = lines[index];
                             AddVariable(player, param[1], randomText);
                         }                        
+                        break;
+                    case ActionType.PlaySound:
+                        int soundId = 0;
+                        if (!int.TryParse(param[0], out soundId)) return;
+                        player.PlaySound(soundId);
                         break;
                 }
             }

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -5937,7 +5937,26 @@ namespace Server.MirObjects
                 }
 
                 int distance = Functions.MaxDistance(CurrentLocation, target.CurrentLocation);
-                int damage = GetAttackPower(MinMC, MaxMC);
+                int minDamage = Math.Max(MinDC, MinMC);
+                int maxDamage = Math.Max(MaxDC, MaxMC);
+
+                if (minDamage == MinDC && maxDamage == MaxDC)
+                {
+                    //we have a dc main
+                }
+                else if (minDamage == MinMC && maxDamage == MaxMC)
+                {
+                    //we have an mc main
+                }
+                else if (minDamage == MinDC && maxDamage == MaxMC)
+                {
+                    minDamage = MinMC;//we have lower dc then mc, but max mc is higher so lets make it an mc roll 
+                }
+                else if (minDamage == MinMC && maxDamage == MaxDC)
+                {
+                    minDamage = MinDC;//we have lower mc then dc, but max dc is higher so lets make it an dc roll 
+                }
+                int damage = GetAttackPower(minDamage, maxDamage);
                 damage = (int)(damage * Math.Max(1, (distance * 0.35)));//range boost
                 damage = ApplyArcherState(damage);
                 int chanceToHit = 60 + (Focus ? 30 : 0) - (int)(distance * 1.5);

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -20404,6 +20404,11 @@ namespace Server.MirObjects
         }
 
         #endregion
+
+        public void PlaySound(int number)
+        {
+            Enqueue(new S.playSound { sound = number });
+        }
     }
 }
 

--- a/ServerPackets.cs
+++ b/ServerPackets.cs
@@ -5687,4 +5687,22 @@ namespace ServerPackets
             writer.Write(Url);
         }
     }
+    public sealed class playSound : Packet
+    {
+        public int sound;
+
+        public override short Index
+        {
+            get { return (short)ServerPacketIds.playSound; }
+        }
+
+        protected override void ReadPacket(BinaryReader reader)
+        {
+            sound = reader.ReadInt32();
+        }
+        protected override void WritePacket(BinaryWriter writer)
+        {
+            writer.Write(sound);
+        }
+    }
 }


### PR DESCRIPTION
This is a change to the rangeattack in playerobject so that it uses either mc (the default of the core files) or dc(what the bows are set up to deal damage with in the commonly used databases.
It works out which is the higher stat and then uses that stat.
so if you have a bow with dc on it and your character is a dc based character you will do DC min / max
but if you are a mc based character with mc stated bows you will do mc min/max

This should allow for expanding the ranged characters later and making for a more versatile system (in my opinion)