### PR TITLE
Made Light sizes bigger due to cut off.

### DIFF
--- a/Client/MirGraphics/DXManager.cs
+++ b/Client/MirGraphics/DXManager.cs
@@ -45,7 +45,7 @@ namespace Client.MirGraphics
 
         public static bool GrayScale;
 
-        public static Point[] LightSizes =
+        public static readonly Point[] LightSizes =
         {
             new Point(125,95),
             new Point(205,156),
@@ -53,11 +53,11 @@ namespace Client.MirGraphics
             new Point(365,277),
             new Point(445,338),
             new Point(525,399),
-            new Point(605,460),
             new Point(685,521),
             new Point(765,581),
             new Point(845,642),
-            new Point(925,703)
+            new Point(925,703),
+            new Point(1005,764)
         };
 
         public static void Create()

--- a/Client/MirGraphics/DXManager.cs
+++ b/Client/MirGraphics/DXManager.cs
@@ -51,13 +51,13 @@ namespace Client.MirGraphics
             new Point(205,156),
             new Point(285,217),
             new Point(365,277),
-            new Point(445,338),
-            new Point(525,399),
-            new Point(685,521),
-            new Point(765,581),
-            new Point(845,642),
-            new Point(925,703),
-            new Point(1005,764)
+            new Point(585,460),
+            new Point(605,581),
+            new Point(765,642),
+            new Point(845,703),
+            new Point(925,764),
+            new Point(1005, 725),
+            new Point(1085,786)
         };
 
         public static void Create()


### PR DESCRIPTION
Due to the small size of some Lights Skills such as Mass Healing & Fire Bang were having their Lights cut off causing the Bounds of the Rectangle being visible rather than blending.