### PR TITLE
Mob AI 9:

### DIFF
--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -618,17 +618,11 @@ namespace Client.MirObjects
                             case Monster.Demonwolf:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.Demonwolf], 312 + (int)Direction * 3, 3, Frame.Count * Frame.Interval, this));
                                 break;
-                            case Monster.DarkBeast:
-                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DarkBeast], 296 + (int)Direction * 4, 4, Frame.Count * Frame.Interval, this));
-                                break;
                             case Monster.HardenRhino:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.HardenRhino], 379 + (int)Direction * 6, 6, Frame.Count * Frame.Interval, this));
                                 break;
                             case Monster.AncientBringer:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.AncientBringer], 512 + (int)Direction * 6, 6, Frame.Count * Frame.Interval, this));
-                                break;
-                            case Monster.DemonGuard:
-                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DemonGuard], 288 + (int)Direction * 2, 2, Frame.Count * Frame.Interval, this));
                                 break;
                             case Monster.Bear:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.Bear], 321 + (int)Direction * 4, 4, Frame.Count * Frame.Interval, this));
@@ -726,9 +720,6 @@ namespace Client.MirObjects
                             case Monster.MudZombie:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.MudZombie], 311, 6, Frame.Count * Frame.Interval, this));
                                 break;
-                            case Monster.WhiteMammoth:
-                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.WhiteMammoth], 376, 5, Frame.Count * Frame.Interval, this));
-                                break;
                             case Monster.DarkBeast:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DarkBeast], 296 + (int)Direction * 4, 4, Frame.Count * Frame.Interval, this));
                                 break;
@@ -743,6 +734,9 @@ namespace Client.MirObjects
                                 break;
                             case Monster.StrayCat:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.StrayCat], 584 + (int)Direction * 6, 6, 6 * Frame.Interval, this));
+                                break;
+                            case Monster.BloodBaboon:
+                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.BloodBaboon], 312 + (int)Direction * 7, 7, 7 * Frame.Interval, this));
                                 break;
                         }
 
@@ -987,8 +981,8 @@ namespace Client.MirObjects
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.IceGuard], 256, 6, Frame.Count * Frame.Interval, this));
                                 break;
                             case Monster.DeathCrawler:
-                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DeathCrawler], 176 + (int)Direction * 9, 9, Frame.Count * FrameInterval, this));
-                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DeathCrawler], 272 + (int)Direction * 4, 4, Frame.Count * FrameInterval, this));
+                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DeathCrawler], 304, 9, Frame.Count * Frame.Interval, this));
+                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DeathCrawler], 313, 11, Frame.Count * Frame.Interval, this));
                                 break;
                             case Monster.BurningZombie:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.BurningZombie], 373, 10, Frame.Count * Frame.Interval, this));
@@ -1502,6 +1496,14 @@ namespace Client.MirObjects
                                         case Monster.OlympicFlame:
                                             if (TrackableEffect.GetOwnerEffectID(this.ObjectID, "CreatureSmoke") < 0)
                                                 Effects.Add(new TrackableEffect(new Effect(Libraries.Pets[((ushort)BaseImage) - 10000], 256, 3, 1000, this), "CreatureSmoke"));
+                                            break;
+                                    }
+                                    break;
+                                case 5:
+                                    switch (BaseImage)
+                                    {
+                                        case Monster.WhiteMammoth:
+                                            Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.WhiteMammoth], 376, 5, Frame.Count * Frame.Interval, this));
                                             break;
                                     }
                                     break;

--- a/Server/MirObjects/Monsters/BloodBaboon.cs
+++ b/Server/MirObjects/Monsters/BloodBaboon.cs
@@ -36,18 +36,15 @@ namespace Server.MirObjects.Monsters
 
             ActionTime = Envir.Time + 300;
             AttackTime = Envir.Time + AttackSpeed;
-            int delay = Functions.MaxDistance(CurrentLocation, Target.CurrentLocation) * 300; //delay for animations
-
 
             if (Envir.Random.Next(5) > 0)
             {
                 Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, Type = 0 });
 
                 int damage = GetAttackPower(MinDC, MaxDC);
-                if (damage == 0) return;
-                //Target.Attacked(this, damage, DefenceType.ACAgility);
+                if (damage == 0) return;                
 
-                DelayedAction action = new DelayedAction(DelayedType.Damage, Envir.Time + delay, Target, damage, DefenceType.ACAgility);
+                DelayedAction action = new DelayedAction(DelayedType.Damage, Envir.Time + 300, Target, damage, DefenceType.ACAgility);
                 ActionList.Add(action);
             }
             else
@@ -60,8 +57,7 @@ namespace Server.MirObjects.Monsters
         private void LineAttack(int distance)
         {
             int damage = GetAttackPower(MinDC, MaxDC * 2);
-            if (damage == 0) return;
-            //Target.Attacked(this, damage, DefenceType.ACAgility);
+            if (damage == 0) return;            
 
             int delay = Functions.MaxDistance(CurrentLocation, Target.CurrentLocation) * 50 + 500; //delay for animations         
             DelayedAction action = new DelayedAction(DelayedType.Damage, Envir.Time + delay, Target, damage, DefenceType.ACAgility);

--- a/Server/MirObjects/Monsters/DarkBeast.cs
+++ b/Server/MirObjects/Monsters/DarkBeast.cs
@@ -25,7 +25,6 @@ namespace Server.MirObjects.Monsters
             ShockTime = 0;
 
             Direction = Functions.DirectionFromPoint(CurrentLocation, Target.CurrentLocation);
-            bool range = !Functions.InRange(CurrentLocation, Target.CurrentLocation, 1);
 
             ActionTime = Envir.Time + 300;
             AttackTime = Envir.Time + AttackSpeed;
@@ -33,7 +32,6 @@ namespace Server.MirObjects.Monsters
             if (Envir.Random.Next(5) > 0)
             {
                 Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation });
-
                 int damage = GetAttackPower(MinDC, MaxDC);
                 if (damage == 0) return;
                 Target.Attacked(this, damage, DefenceType.ACAgility);
@@ -41,11 +39,11 @@ namespace Server.MirObjects.Monsters
             else
             {
                 Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, Type = 1 });
-                LineAttack(2);
+                Attack2();
             }
         }
 
-        private void LineAttack(int distance)
+        private void Attack2()
         {
             int damage = GetAttackPower(MinDC, MaxDC * 2);
             if (damage == 0) return;
@@ -54,7 +52,7 @@ namespace Server.MirObjects.Monsters
             if (Envir.Random.Next(5) == 0)
                 if (Envir.Random.Next(Settings.PoisonResistWeight) >= Target.PoisonResist)
                 {
-                    Target.ApplyPoison(new Poison { PType = PoisonType.Red, Duration = 5, TickSpeed = 1000 }, this);
+                    Target.ApplyPoison(new Poison { PType = PoisonType.Bleeding, Duration = 5, TickSpeed = 1000 }, this);
                 }
         }
 

--- a/Server/MirObjects/Monsters/DeathCrawler.cs
+++ b/Server/MirObjects/Monsters/DeathCrawler.cs
@@ -15,20 +15,6 @@ namespace Server.MirObjects.Monsters
         {
         }
 
-        protected override void Attack()
-        {
-            if (!Target.IsAttackTarget(this))
-            {
-                Target = null;
-                return;
-            }
-
-            ShockTime = 0;
-
-            Direction = Functions.DirectionFromPoint(CurrentLocation, Target.CurrentLocation);
-            Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation });
-        }
-
         public override void Die()
         {
             ActionList.Add(new DelayedAction(DelayedType.Die, Envir.Time + 500));

--- a/Server/MirObjects/Monsters/DemonWolf.cs
+++ b/Server/MirObjects/Monsters/DemonWolf.cs
@@ -9,6 +9,7 @@ using System.Text;
 
 namespace Server.MirObjects.Monsters
 {
+    // TODO: ADD ATTACK AS PER ANIMATIONS 354 - DASH THROUGH PLAYER ATTACK?
     class DemonWolf : MonsterObject
     {
         protected internal DemonWolf(MonsterInfo info)

--- a/Server/MirObjects/Monsters/WhiteMammoth.cs
+++ b/Server/MirObjects/Monsters/WhiteMammoth.cs
@@ -20,14 +20,25 @@ namespace Server.MirObjects.Monsters
 
             Direction = Functions.DirectionFromPoint(CurrentLocation, Target.CurrentLocation);
 
-            if (Envir.Random.Next(10) > 0)
+            if (Envir.Random.Next(8) > 0)
             {
-                base.Attack();
+                if (Envir.Random.Next(6) > 0)
+                {
+                    base.Attack();
+                }
+                else
+                {
+                    Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, Type = 1 });
+                    int damage = GetAttackPower(MinDC, MaxDC * 2);
+                    if (damage == 0) return;
+                    Target.Attacked(this, damage);
+                }
+                
             }
             else
             {
-                Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, Type = 1 });
-                Attack2();
+                Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, Type = 2 });
+                Attack3();
             }
 
             ShockTime = 0;
@@ -35,10 +46,11 @@ namespace Server.MirObjects.Monsters
             AttackTime = Envir.Time + AttackSpeed;
 
         }
-        private void Attack2()
+        private void Attack3()
         {
             int damage = GetAttackPower(MinDC, MaxDC);
             if (damage == 0) return;
+            Target.Attacked(this, damage);
 
             if (Envir.Random.Next(Settings.PoisonResistWeight) >= Target.PoisonResist)
             {

--- a/Shared/Enums.cs
+++ b/Shared/Enums.cs
@@ -453,7 +453,7 @@ public enum Monster : ushort
     IceGuard = 249, // Done (DG)
     ElementGuard = 250, // Done (DG)
     DemonGuard = 251, // Done (DG)
-    KingGuard = 252, // Done (DG)
+    KingGuard = 252, //TODO: AI Incomplete - Needs revisiting
     Snake10 = 253,//done
     Snake11 = 254,//done
     Snake12 = 255,//done
@@ -486,7 +486,7 @@ public enum Monster : ushort
     Jar2 = 281,
     SeedingsGeneral = 282, // Done (DG)
     RestlessJar = 283,
-    GeneralJinmYo = 284, // AI Incomplete - Thunderbolt and orb at end of lib file, not sure what this does? See notes in AI file (DG).
+    GeneralJinmYo = 284, // TODO: AI Incomplete - Thunderbolt and orb at end of lib file, not sure what this does? See notes in AI file (DG).
     Bunny = 285, 
     Tucson = 286, //No AI or spell animations (DG)
     TucsonFighter = 287, // Use AI 44 - No spell animation (DG)


### PR DESCRIPTION
### **Removed:**
     * DemonGuard animation duplicate in Attack1

### **Amended:** 
     * DeathCrawler Die animations
     * DeathCrawler AI (Removed Attack override, was overriding base code with the exact same code).
     * WhiteMammoth AI, added third attack (Stomp) and corrected damage.
     * BloodBaboon - Tidied up and removed redundant AI code.

### **Added:**
     * BloodBaboon spell animation (shadow).

### The following Lib files will also need updating:
     * 251.lib
     * 267.lib
     * 268.lib
     * 269.lib
     * 287.lib