### PR TITLE
Mob AI 24:

### DIFF
--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -1053,6 +1053,9 @@ namespace Client.MirObjects
                             case Monster.DragonWarrior:
                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.DragonWarrior], 504 + (int)Direction * 6, 6, 6 * Frame.Interval, this));
                                 break;
+                            case Monster.FloatingRock:
+                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.FloatingRock], 151, 8, Frame.Count * Frame.Interval, this));
+                                break;
                         }
                         PlayDieSound();
                         break;
@@ -1448,6 +1451,9 @@ namespace Client.MirObjects
                                             case Monster.FrozenAxeman:
                                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.FrozenAxeman], 528 + (int)Direction * 3, 3, 300, this));
                                                 break;
+                                            case Monster.ScalyBeast:
+                                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.ScalyBeast], 344 + (int)Direction * 3, 3, 3 * Frame.Interval, this));
+                                                break;
                                         }
                                         break;
                                     }
@@ -1559,7 +1565,6 @@ namespace Client.MirObjects
                                                     ob.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.Bear], 312, 9, 900, ob));
                                                 }
                                                 break;
-
                                         }
                                     }
                                     break;
@@ -1686,6 +1691,9 @@ namespace Client.MirObjects
                                             case Monster.SwampSlime:
                                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.SwampSlime], 368, 9, 900, this) { Blend = true });
                                                 break;
+                                            case Monster.ScalyBeast:
+                                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.ScalyBeast], 368 + (int)Direction * 3, 3, 3 * Frame.Interval, this) { Blend = false });
+                                                break;
                                         }
                                     }
                                     break;
@@ -1695,6 +1703,16 @@ namespace Client.MirObjects
                                         {
                                             case Monster.StrayCat:
                                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.StrayCat], 584 + (int)Direction * 6, 6, 6 * Frame.Interval, this));
+                                                break;
+                                        }
+                                    }
+                                    break;
+                                case 9:
+                                    {
+                                        switch (BaseImage)
+                                        {
+                                            case Monster.ScalyBeast:
+                                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.ScalyBeast], 392, 3, 300, this) { Blend = true });
                                                 break;
                                         }
                                     }
@@ -1875,6 +1893,9 @@ namespace Client.MirObjects
                                             case Monster.OmaWitchDoctor:
                                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.OmaWitchDoctor], 792 + (int)Direction * 7, 7, 7 * Frame.Interval, this));
                                                 break;
+                                            case Monster.FloatingRock:
+                                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.FloatingRock], 159 + (int)Direction * 7, 7, 7 * Frame.Interval, this));
+                                                break;
                                         }
                                         break;
                                     }
@@ -1893,6 +1914,19 @@ namespace Client.MirObjects
                                                 break;
                                             case Monster.FrozenMagician:
                                                 Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.FrozenMagician], 512 + (int)Direction * 6, 6, 6 * Frame.Interval, this));
+                                                break;
+                                        }
+                                        break;
+                                    }
+                                case 3:
+                                    {
+                                        switch (BaseImage)
+                                        {
+                                            case Monster.HornedArcher:
+                                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.HornedArcher], 336 + (int)Direction * 3, 3, 3 * Frame.Interval, this, drawBehind: true));
+                                                break;
+                                            case Monster.ColdArcher:
+                                                Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.ColdArcher], 336 + (int)Direction * 3, 3, 3 * Frame.Interval, this, drawBehind: true));
                                                 break;
                                         }
                                         break;
@@ -2315,6 +2349,32 @@ namespace Client.MirObjects
                                                     ob.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.HornedMage], 780, 9, 800, ob) /*{ Blend = false }*/);
                                                 }
                                                 break;
+                                            case Monster.ColdArcher:
+                                                missile = CreateProjectile(360, Libraries.Monsters[(ushort)Monster.HornedArcher], true, 3, 50, 0, direction16: true);
+                                                //missile = CreateProjectile(368, Libraries.Monsters[(ushort)Monster.ColdArcher], true, 2, 50, 0 );
+
+                                                if (missile.Target != null)
+                                                {
+                                                    missile.Complete += (o, e) =>
+                                                    {
+                                                        if (missile.Target.CurrentAction == MirAction.Dead) return;
+                                                        missile.Target.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.ColdArcher], 384, 10, 1000, missile.Target) { Blend = true });
+                                                    };
+                                                }
+                                                break;
+                                            case Monster.HornedArcher:
+                                                missile = CreateProjectile(360, Libraries.Monsters[(ushort)Monster.HornedArcher], true, 3, 50, 0, direction16: true);
+
+                                                if (missile.Target != null)
+                                                {
+                                                    missile.Complete += (o, e) =>
+                                                    {
+                                                        if (missile.Target.CurrentAction == MirAction.Dead) return;
+                                                        missile.Target.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.HornedArcher], 408, 6, 500, missile.Target) { Blend = true });
+                                                    };
+                                                }
+                                                break;
+                                                //END OF CASE 4.
                                         }
                                         break;
                                     }
@@ -2409,6 +2469,15 @@ namespace Client.MirObjects
                                                 {
                                                     ob.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.IcePhantom], 682, 10, 1000, ob) { Blend = true });
                                                     SoundManager.PlaySound(BaseSound + 6); //is this the correct sound for this mob attack?
+                                                }
+                                                break;
+                                            case Monster.FloatingRock:
+                                                ob = MapControl.GetObject(TargetID);
+                                                if (ob != null)
+                                                {
+                                                    ob.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.FloatingRock], 226, 10, 1000, ob));
+                                                    SoundManager.PlaySound(BaseSound + 6);
+
                                                 }
                                                 break;
                                         }
@@ -2541,6 +2610,30 @@ namespace Client.MirObjects
                                                 {
                                                     ob.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.IcePhantom], 772, 7, 700, ob) { Blend = true });
                                                     SoundManager.PlaySound(BaseSound + 6); //is this the correct sound for this mob attack?
+                                                }
+                                                break;
+                                            case Monster.ColdArcher:
+                                                missile = CreateProjectile(394, Libraries.Monsters[(ushort)Monster.ColdArcher], true, 3, 50, 0, direction16: true);
+
+                                                if (missile.Target != null)
+                                                {
+                                                    missile.Complete += (o, e) =>
+                                                    {
+                                                        if (missile.Target.CurrentAction == MirAction.Dead) return;
+                                                        missile.Target.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.ColdArcher], 442, 6, 500, missile.Target) { Blend = true });
+                                                    };
+                                                }
+                                                break;
+                                            case Monster.HornedArcher:
+                                                missile = CreateProjectile(414, Libraries.Monsters[(ushort)Monster.HornedArcher], true, 3, 50, 0, direction16: true);
+
+                                                if (missile.Target != null)
+                                                {
+                                                    missile.Complete += (o, e) =>
+                                                    {
+                                                        if (missile.Target.CurrentAction == MirAction.Dead) return;
+                                                        missile.Target.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.HornedArcher], 462, 6, 500, missile.Target) { Blend = true });
+                                                    };
                                                 }
                                                 break;
                                         }
@@ -4189,7 +4282,16 @@ namespace Client.MirObjects
                         }
                         break;
                     }
-            }
+                case Monster.FloatingRock:
+                    switch (CurrentAction)
+                    {
+                        case MirAction.AttackRange1:
+                            Libraries.Monsters[(ushort)Monster.FloatingRock].DrawBlend(215 + FrameIndex + 10, DrawLocation, Color.White, true);
+                            break;
+                    }
+                    break;
+
+            } //END OF DRAW EFFECTS
         }
 
         public override void DrawName()

--- a/Legend of Mir.sln
+++ b/Legend of Mir.sln
@@ -43,7 +43,6 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "PatcherWebSite", "PatcherWe
 		Release.AspNetCompiler.FixedNames = "false"
 		Release.AspNetCompiler.Debug = "False"
 		VWDPort = "50790"
-		SlnRelativePath = "PatcherWebSite\"
 	EndProjectSection
 EndProject
 Global
@@ -101,7 +100,6 @@ Global
 		{3B6D8439-1B92-4383-BBE7-E29A26E8F938}.Release|x86.ActiveCfg = Release|Any CPU
 		{A779B96A-AE74-47E7-B0CA-A02B26C1F61E}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{A779B96A-AE74-47E7-B0CA-A02B26C1F61E}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{A779B96A-AE74-47E7-B0CA-A02B26C1F61E}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{A779B96A-AE74-47E7-B0CA-A02B26C1F61E}.Debug|x64.ActiveCfg = Debug|x64
 		{A779B96A-AE74-47E7-B0CA-A02B26C1F61E}.Debug|x64.Build.0 = Debug|x64
 		{A779B96A-AE74-47E7-B0CA-A02B26C1F61E}.Debug|x86.ActiveCfg = Debug|x86
@@ -116,7 +114,6 @@ Global
 		{B495D846-0344-468C-8D2D-6D850E0A9700}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B495D846-0344-468C-8D2D-6D850E0A9700}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B495D846-0344-468C-8D2D-6D850E0A9700}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{B495D846-0344-468C-8D2D-6D850E0A9700}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{B495D846-0344-468C-8D2D-6D850E0A9700}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{B495D846-0344-468C-8D2D-6D850E0A9700}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{B495D846-0344-468C-8D2D-6D850E0A9700}.Debug|x86.Build.0 = Debug|Any CPU

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -335,7 +335,14 @@ namespace Server.MirObjects
                     return new IceCrystalSoldier(info);
                 case 160:
                     return new DarkWraith(info);
-
+                case 161:
+                    return new ColdArcher(info);
+                case 162:
+                    return new HornedArcher(info);
+                case 163:
+                    return new FloatingRock(info);
+                case 164:
+                    return new ScalyBeast(info);
 
                 //unfinished
                 case 120:

--- a/Server/MirObjects/Monsters/ColdArcher.cs
+++ b/Server/MirObjects/Monsters/ColdArcher.cs
@@ -1,0 +1,120 @@
+﻿using Server.MirDatabase;
+using S = ServerPackets;
+
+namespace Server.MirObjects.Monsters
+{
+    public class ColdArcher : MonsterObject
+    {
+        public long FearTime;
+        public byte AttackRange = 8;
+
+        protected internal ColdArcher(MonsterInfo info)
+            : base(info)
+        {
+        }
+
+        protected override bool InAttackRange()
+        {
+            return CurrentMap == Target.CurrentMap && Functions.InRange(CurrentLocation, Target.CurrentLocation, AttackRange);
+        }
+
+        protected override void Attack()
+        {
+            if (!Target.IsAttackTarget(this))
+            {
+                Target = null;
+                return;
+            }
+
+            ShockTime = 0;
+
+            Direction = Functions.DirectionFromPoint(CurrentLocation, Target.CurrentLocation);
+            ActionTime = Envir.Time + 300;
+            AttackTime = Envir.Time + AttackSpeed;
+            int delay = Functions.MaxDistance(CurrentLocation, Target.CurrentLocation) * 50 + 500; //50 MS per Step
+
+            if (Envir.Random.Next(6) != 0)
+            {
+                Broadcast(new S.ObjectRangeAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, TargetID = Target.ObjectID });
+                int damage = GetAttackPower(Stats[Stat.MinDC], Stats[Stat.MaxDC]);
+                if (damage == 0) return;
+
+                DelayedAction action = new DelayedAction(DelayedType.RangeDamage, Envir.Time + delay, Target, damage, DefenceType.ACAgility);
+                ActionList.Add(action);
+            }
+            else
+            {
+                Broadcast(new S.ObjectRangeAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, TargetID = Target.ObjectID, Type = 1 });
+                int damage = GetAttackPower(Stats[Stat.MinMC], Stats[Stat.MaxMC]);
+                if (damage == 0) return;
+
+                if (Envir.Random.Next(Settings.PoisonResistWeight) >= Target.Stats[Stat.PoisonResist])
+                {
+
+                    if (Envir.Random.Next(2) == 0)
+                    {
+                        Target.ApplyPoison(new Poison { Owner = this, Duration = 5, PType = PoisonType.Frozen, Value = GetAttackPower(Stats[Stat.MinSC], Stats[Stat.MaxSC]), TickSpeed = 1000 }, this);
+                    }
+                }
+                DelayedAction action = new DelayedAction(DelayedType.RangeDamage, Envir.Time + delay, Target, damage, DefenceType.MACAgility);
+                ActionList.Add(action);
+            }
+
+            if (Target.Dead)
+                FindTarget();
+        }
+
+        protected override void ProcessTarget()
+        {
+            if (Target == null || !CanAttack) return;
+
+            if (InAttackRange() && Envir.Time < FearTime)
+            {
+                Attack();
+                return;
+            }
+
+            FearTime = Envir.Time + 5000;
+
+            if (Envir.Time < ShockTime)
+            {
+                Target = null;
+                return;
+            }
+
+            int dist = Functions.MaxDistance(CurrentLocation, Target.CurrentLocation);
+
+            if (dist >= AttackRange)
+                MoveTo(Target.CurrentLocation);
+            else
+            {
+                MirDirection dir = Functions.DirectionFromPoint(Target.CurrentLocation, CurrentLocation);
+
+                if (Walk(dir)) return;
+
+                switch (Envir.Random.Next(2)) //No favour
+                {
+                    case 0:
+                        for (int i = 0; i < 7; i++)
+                        {
+                            dir = Functions.NextDir(dir);
+
+                            if (Walk(dir))
+                                return;
+                        }
+                        break;
+                    default:
+                        for (int i = 0; i < 7; i++)
+                        {
+                            dir = Functions.PreviousDir(dir);
+
+                            if (Walk(dir))
+                                return;
+                        }
+                        break;
+                }
+
+            }
+        }
+    }
+}

--- a/Server/MirObjects/Monsters/FloatingRock.cs
+++ b/Server/MirObjects/Monsters/FloatingRock.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Drawing;
+using Server.MirDatabase;
+using Server.MirEnvir;
+using S = ServerPackets;
+using System.Collections.Generic;
+namespace Server.MirObjects.Monsters
+{
+    class FloatingRock : MonsterObject
+    {
+        protected override bool CanMove { get { return false; } }
+
+        protected virtual byte AttackRange
+        {
+            get
+            {
+                return 7;
+            }
+        }
+
+        protected internal FloatingRock(MonsterInfo info)
+            : base(info)
+        {
+        }
+
+        //public override void Turn(MirDirection dir)
+        //{
+        //}
+        public override bool Walk(MirDirection dir) { return false; }
+
+        protected override bool InAttackRange()
+        {
+            return CurrentMap == Target.CurrentMap && Functions.InRange(CurrentLocation, Target.CurrentLocation, AttackRange);
+        }
+
+        protected override void Attack()
+        {
+
+            if (!Target.IsAttackTarget(this))
+            {
+                Target = null;
+                return;
+            }
+
+            ShockTime = 0;
+            Direction = Functions.DirectionFromPoint(CurrentLocation, Target.CurrentLocation);
+            bool ranged = CurrentLocation == Target.CurrentLocation || !Functions.InRange(CurrentLocation, Target.CurrentLocation, 1);
+
+            ActionTime = Envir.Time + 300;
+            AttackTime = Envir.Time + AttackSpeed;
+
+            Broadcast(new S.ObjectRangeAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, TargetID = Target.ObjectID });
+
+            int damage = GetAttackPower(Stats[Stat.MinMC], Stats[Stat.MaxMC]);
+            if (damage == 0) return;
+            DelayedAction action = new DelayedAction(DelayedType.Damage, Envir.Time + 1000, Target, damage, DefenceType.MAC);
+            ActionList.Add(action);
+
+            if (Target.Dead)
+                FindTarget();
+        }
+
+        protected override void ProcessRoam() { }
+    }
+}

--- a/Server/MirObjects/Monsters/HornedArcher.cs
+++ b/Server/MirObjects/Monsters/HornedArcher.cs
@@ -1,0 +1,126 @@
+﻿using Server.MirDatabase;
+using S = ServerPackets;
+
+namespace Server.MirObjects.Monsters
+{
+    // TODO - 3 BUFFS TO CODE
+    // Can buff all mobs around it
+    // Look at Yin/Yan Devil Nodes from Past Bichon?
+    // Add their spell effects to SpellObjects.cs
+    // Loop the animation while the buff is active.
+
+    public class HornedArcher : MonsterObject
+    {
+        public long FearTime;
+        public byte AttackRange = 8;
+
+        protected internal HornedArcher(MonsterInfo info)
+            : base(info)
+        {
+        }
+
+        protected override bool InAttackRange()
+        {
+            return CurrentMap == Target.CurrentMap && Functions.InRange(CurrentLocation, Target.CurrentLocation, AttackRange);
+        }
+
+        protected override void Attack()
+        {
+            if (!Target.IsAttackTarget(this))
+            {
+                Target = null;
+                return;
+            }
+
+            ShockTime = 0;
+
+            Direction = Functions.DirectionFromPoint(CurrentLocation, Target.CurrentLocation);
+            ActionTime = Envir.Time + 300;
+            AttackTime = Envir.Time + AttackSpeed;
+            int delay = Functions.MaxDistance(CurrentLocation, Target.CurrentLocation) * 50 + 500; //50 MS per Step
+
+            if (Envir.Random.Next(6) != 0)
+            {
+                Broadcast(new S.ObjectRangeAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, TargetID = Target.ObjectID });
+                int damage = GetAttackPower(Stats[Stat.MinDC], Stats[Stat.MaxDC]);
+                if (damage == 0) return;
+
+                DelayedAction action = new DelayedAction(DelayedType.RangeDamage, Envir.Time + delay, Target, damage, DefenceType.ACAgility);
+                ActionList.Add(action);
+            }
+            else
+            {
+                Broadcast(new S.ObjectRangeAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, TargetID = Target.ObjectID, Type = 1 });
+                int damage = GetAttackPower(Stats[Stat.MinMC], Stats[Stat.MaxMC]);
+                if (damage == 0) return;
+
+                if (Envir.Random.Next(Settings.PoisonResistWeight) >= Target.Stats[Stat.PoisonResist])
+                {
+                    if (Envir.Random.Next(2) == 0)
+                    {
+                        Target.ApplyPoison(new Poison { Owner = this, Duration = 8, PType = PoisonType.Stun, Value = GetAttackPower(Stats[Stat.MinSC], Stats[Stat.MaxSC]), TickSpeed = 1000 }, this);
+                    }
+                }
+
+                DelayedAction action = new DelayedAction(DelayedType.RangeDamage, Envir.Time + delay, Target, damage, DefenceType.MACAgility);
+                ActionList.Add(action);
+            }
+
+            if (Target.Dead)
+                FindTarget();
+        }
+
+        protected override void ProcessTarget()
+        {
+            if (Target == null || !CanAttack) return;
+
+            if (InAttackRange() && Envir.Time < FearTime)
+            {
+                Attack();
+                return;
+            }
+
+            FearTime = Envir.Time + 5000;
+
+            if (Envir.Time < ShockTime)
+            {
+                Target = null;
+                return;
+            }
+
+            int dist = Functions.MaxDistance(CurrentLocation, Target.CurrentLocation);
+
+            if (dist >= AttackRange)
+                MoveTo(Target.CurrentLocation);
+            else
+            {
+                MirDirection dir = Functions.DirectionFromPoint(Target.CurrentLocation, CurrentLocation);
+
+                if (Walk(dir)) return;
+
+                switch (Envir.Random.Next(2)) //No favour
+                {
+                    case 0:
+                        for (int i = 0; i < 7; i++)
+                        {
+                            dir = Functions.NextDir(dir);
+
+                            if (Walk(dir))
+                                return;
+                        }
+                        break;
+                    default:
+                        for (int i = 0; i < 7; i++)
+                        {
+                            dir = Functions.PreviousDir(dir);
+
+                            if (Walk(dir))
+                                return;
+                        }
+                        break;
+                }
+
+            }
+        }
+    }
+}

--- a/Server/MirObjects/Monsters/ScalyBeast.cs
+++ b/Server/MirObjects/Monsters/ScalyBeast.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Drawing;
+using Server.MirDatabase;
+using Server.MirEnvir;
+using S = ServerPackets;
+using System.Collections.Generic;
+
+namespace Server.MirObjects.Monsters
+{
+    public class ScalyBeast : MonsterObject
+    {
+        protected internal ScalyBeast(MonsterInfo info)
+            : base(info)
+        {
+        }
+
+        protected override void Attack()
+        {
+            if (!Target.IsAttackTarget(this))
+            {
+                Target = null;
+                return;
+            }
+
+            ActionTime = Envir.Time + 300;
+            AttackTime = Envir.Time + AttackSpeed;
+            ShockTime = 0;
+
+            Direction = Functions.DirectionFromPoint(CurrentLocation, Target.CurrentLocation);
+
+            if (Envir.Random.Next(3) > 0)
+            {
+                Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, Type = 0 });
+                int damage = GetAttackPower(Stats[Stat.MinDC], Stats[Stat.MaxDC]);
+                if (damage == 0) return;
+
+                DelayedAction action = new DelayedAction(DelayedType.Damage, Envir.Time + 500, Target, damage, DefenceType.MAC);
+                ActionList.Add(action);
+            }
+            else
+            {
+                Broadcast(new S.ObjectAttack { ObjectID = ObjectID, Direction = Direction, Location = CurrentLocation, Type = 1 });
+                LineAttack();
+            }
+
+        }
+
+        private void AttackDetails()
+        {
+
+        }
+
+        private void LineAttack()
+        {
+            List<MapObject> targets = FindAllTargets(2, CurrentLocation);
+            if (targets.Count == 0) return;
+
+            for (int i = 0; i < targets.Count; i++)
+            {
+                int damage = GetAttackPower(Stats[Stat.MinDC], Stats[Stat.MaxDC]);
+                if (damage == 0) return;
+                DelayedAction action = new DelayedAction(DelayedType.Damage, Envir.Time + 900, targets[i], damage, DefenceType.MAC);
+                ActionList.Add(action);
+
+                if (Envir.Random.Next(Settings.PoisonResistWeight) >= Target.Stats[Stat.PoisonResist])
+                {
+                    if (Envir.Random.Next(5) == 0)
+                    {
+                        targets[i].ApplyPoison(new Poison { Owner = this, Duration = 4, PType = PoisonType.Paralysis, Value = GetAttackPower(Stats[Stat.MinSC], Stats[Stat.MaxSC]), TickSpeed = 1000 }, this);
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/Shared/Enums.cs
+++ b/Shared/Enums.cs
@@ -474,7 +474,7 @@ public enum Monster : ushort
     SeedingsGeneral = 282, // Done (DG)
     RestlessJar = 283,
     GeneralJinmYo = 284, // TODO: AI Incomplete - Thunderbolt and orb at end of lib file, not sure what this does? See notes in AI file (DG).
-    Bunny = 285, 
+    Bunny = 285, // No AI
     Tucson = 286, //No AI or spell animations (DG)
     TucsonFighter = 287, // Use AI 44 - No spell animation (DG)
     TucsonMage = 288, // Done (DG)
@@ -531,10 +531,10 @@ public enum Monster : ushort
     Hydrax = 338, // Done (DG) - No AI
     HornedMage = 339, // Done (jxtulong)
     Blank4 = 340,
-    HornedArcher = 341,
-    ColdArcher = 342,
-    HornedWarrior = 343,
-    FloatingRock = 344,
+    HornedArcher = 341, // Incomplete AI (DG) - Need to code the buffs.
+    ColdArcher = 342, // Done (DG) - //TODO - check wemade file for arrow issue
+    HornedWarrior = 343, // TODO - HAS BUFF MECHANIC
+    FloatingRock = 344, // Done (DG)
     ScalyBeast = 345,
     HornedSorceror = 346,
     BoulderSpirit = 347,


### PR DESCRIPTION
### **Amended:**
* ScalyBeast (345.lib) - Removed blank frames from attacks (Duplicated one set of attack2 frames as only 7 pairs of frames were present).

### **Added:**
* ColdArcher - AI and spell animations
* FloatingRock - AI and spell animations
* HornedArcher - AI and spell animations (Buffs to be added to AI).
* ScalyBeast - AI and spell animations

### _--------- Notes: ---------_ 

ColdArcher Arrow frames incomplete (arrow shooting wonky) - set as HornedArcher arrow temporarily? (Need to check WeMade Files as I suspect there may have been blanks which were removed).