### PR TITLE
[BUG] - Colour not correctly updating

### DIFF
--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -1631,10 +1631,7 @@ namespace Server.MirObjects
                 else
                     colour = Color.Blue;
             }
-       
-            if (MyGuild != null && MyGuild.IsAtWar())
-                colour = Color.Blue;
-       
+
             if (Envir.Time < BrownTime)
                 colour = Color.SaddleBrown;
 


### PR DESCRIPTION
- Starting a war with another guild shows them as BLUE until you relog, which it then corrects itself to ORANGE.
- All players on the server will see everyone at war as BLUE even though they are not at war with anyone, which creates confusion.

Name colour changes don't correctly update with this in place.

It is also not required as it's being updated already from GetNameColour