### PR TITLE
[BUG FIX] Crafting Gold Count 

### DIFF
--- a/Server/MirObjects/NPC/NPCScript.cs
+++ b/Server/MirObjects/NPC/NPCScript.cs
@@ -1437,8 +1437,8 @@ namespace Server.MirObjects
             }
 
             //Take Gold
-            player.Account.Gold -= recipe.Gold;
-            player.Enqueue(new S.LoseGold { Gold = recipe.Gold });
+            player.Account.Gold -= (recipe.Gold * count);
+            player.Enqueue(new S.LoseGold { Gold = (recipe.Gold * count) });
 
             if (Envir.Random.Next(100) >= recipe.Chance + player.Stats[Stat.CraftRatePercent])
             {

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -1631,10 +1631,7 @@ namespace Server.MirObjects
                 else
                     colour = Color.Blue;
             }
-       
-            if (MyGuild != null && MyGuild.IsAtWar())
-                colour = Color.Blue;
-       
+
             if (Envir.Time < BrownTime)
                 colour = Color.SaddleBrown;
 


### PR DESCRIPTION
Crafting multiples was not taking the gold cost correctly and had a missing count on removal.