### PR TITLE
Client Resolution QOL

### DIFF
--- a/Client/Forms/Config.cs
+++ b/Client/Forms/Config.cs
@@ -1,6 +1,7 @@
 ﻿using Client;
 using System.Resources;
 using System.Reflection;
+using Client.Resolution;
 
 namespace Launcher
 {
@@ -18,14 +19,17 @@ namespace Launcher
             this.AutoStart_label.Text = GameLanguage.Autostart;
             this.ID_l.Text = GameLanguage.Usrname;
             this.Password_l.Text = GameLanguage.Password;
+
+            DrawSupportedResolutions();
         }
                                    
         private void Res1_pb_Click(object sender, EventArgs e)
         {
-            resolutionChoice(1024);
+            resolutionChoice(eSupportedResolution.w1024h768);
+
         }
 
-        public void resolutionChoice(int res)
+        public void resolutionChoice(eSupportedResolution res)
         {
             Res2_pb.Image = Client.Resources.Images.Radio_Unactive;
             Res3_pb.Image = Client.Resources.Images.Radio_Unactive;
@@ -34,32 +38,32 @@ namespace Launcher
 
             switch (res)
             {
-                case 1024:
+                case eSupportedResolution.w1024h768:
                     Res2_pb.Image = Client.Resources.Images.Config_Radio_On;
                     break;
-                case 1366:
+                case eSupportedResolution.w1366h768:
                     Res3_pb.Image = Client.Resources.Images.Config_Radio_On;
                     break;
-                case 1280:
+                case eSupportedResolution.w1280h720:
                     Res4_pb.Image = Client.Resources.Images.Config_Radio_On;
                     break;
-                case 1920:
+                case eSupportedResolution.w1920h1080:
                     Res5_pb.Image = Client.Resources.Images.Config_Radio_On;
                     break;
 
             }
 
-            Settings.Resolution = res;
+            Settings.Resolution = (int)res;
         }
 
         private void Res2_pb_Click(object sender, EventArgs e)
         {
-            resolutionChoice(1024);
+            resolutionChoice(eSupportedResolution.w1024h768);
         }
 
         private void Res3_pb_Click(object sender, EventArgs e)
         {
-            resolutionChoice(1366);
+            resolutionChoice(eSupportedResolution.w1366h768);
         }
 
         private void Config_VisibleChanged(object sender, EventArgs e)
@@ -68,7 +72,7 @@ namespace Launcher
             {
                 AccountLogin_txt.Text = Settings.AccountID;
                 AccountPass_txt.Text = Settings.Password;
-                resolutionChoice(Settings.Resolution);
+                resolutionChoice((eSupportedResolution)Settings.Resolution);
 
                 Fullscreen_pb.Image = Settings.FullScreen
                     ? Client.Resources.Images.Config_Check_On
@@ -194,12 +198,47 @@ namespace Launcher
 
         private void Res4_pb_Click(object sender, EventArgs e)
         {
-            resolutionChoice(1280);
+            resolutionChoice(eSupportedResolution.w1280h720);
         }
 
         private void Res5_pb_Click(object sender, EventArgs e)
         {
-            resolutionChoice(1920);
+            resolutionChoice(eSupportedResolution.w1920h1080);
+        }
+
+        private void DrawSupportedResolutions()
+        {
+            Res2_pb.Enabled = false;
+            label2.ForeColor = Color.Red;
+            Res4_pb.Enabled = false;
+            label5.ForeColor = Color.Red;
+            Res3_pb.Enabled = false;
+            label3.ForeColor = Color.Red;
+            Res5_pb.Enabled = false;
+            label1.ForeColor = Color.Red;
+
+            foreach (eSupportedResolution supportedResolution in DisplayResolutions.DisplaySupportedResolutions)
+            {
+                switch (supportedResolution)
+                {
+                    case (eSupportedResolution.w1024h768):
+                        Res2_pb.Enabled = true;
+                        label2.ForeColor = Color.Gray;
+                        break;
+                    case (eSupportedResolution.w1280h720):
+                        Res4_pb.Enabled = true;
+                        label5.ForeColor = Color.Gray;
+                        break;
+                    case (eSupportedResolution.w1366h768):
+                        Res3_pb.Enabled = true;
+                        label3.ForeColor = Color.Gray;
+                        break;
+                    case (eSupportedResolution.w1920h1080):
+                        Res5_pb.Enabled = true;
+                        label1.ForeColor = Color.Gray;
+                        break;
+                }
+            }
         }
     }
 }

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -2,6 +2,7 @@
 using Launcher;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using Client.Resolution;
 
 namespace Client
 {
@@ -38,6 +39,8 @@ namespace Client
 
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
+
+                CheckResolutionSetting();
 
                 if (Settings.P_Patcher) Application.Run(PForm = new Launcher.AMain());
                 else Application.Run(Form = new CMain());
@@ -148,6 +151,27 @@ namespace Client
 
                 [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
                 void BindAsLegacyV2Runtime();
+            }
+        }
+
+        public static void CheckResolutionSetting()
+        {
+            var parsedOK = DisplayResolutions.GetDisplayResolutions();
+            if (!parsedOK)
+            {
+                MessageBox.Show("Could not get display resolutions", "Get Display Resolution Issue", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                Environment.Exit(0);
+            }
+
+            if (!DisplayResolutions.IsSupported(Settings.Resolution))
+            {
+                MessageBox.Show($"Client does not support {Settings.Resolution}. Setting Resolution to 1024x768.",
+                                "Invalid Client Resolution",
+                                MessageBoxButtons.OK,
+                                MessageBoxIcon.Error);
+
+                Settings.Resolution = (int)eSupportedResolution.w1024h768;
+                Settings.Save();
             }
         }
 

--- a/Client/Resolution/DisplayResolutions.cs
+++ b/Client/Resolution/DisplayResolutions.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Client.Resolution
+{
+    internal static class DisplayResolutions
+    {
+        internal static List<eSupportedResolution> DisplaySupportedResolutions = new List<eSupportedResolution>();
+
+        internal static bool GetDisplayResolutions()
+        {
+            bool parsedOK = false;
+
+            var supportedResolutions = Enum.GetNames(typeof(eSupportedResolution));
+            try
+            {
+                List<string> list = new();
+
+                DEVMODE vDevMode = new DEVMODE();
+                int i = 0;
+                while (EnumDisplaySettings(null, i, ref vDevMode))
+                {
+                    string displayResolution = $"w{vDevMode.dmPelsWidth}h{vDevMode.dmPelsHeight}";
+
+                    if(supportedResolutions.Contains(displayResolution))
+                    {
+                        if (!list.Contains(displayResolution))
+                        {
+                            list.Add(displayResolution);
+                        }
+                    }
+                    i++;
+                }
+
+                if (list.Count > 0)
+                {
+                    foreach (string displayResolution in list)
+                    {
+                        eSupportedResolution resolution;
+                        if (Enum.TryParse(displayResolution, true, out resolution))
+                        {
+                            DisplaySupportedResolutions.Add(resolution);
+                        }
+                    }
+                }
+
+                if (DisplaySupportedResolutions.Count > 0)
+                {
+                    parsedOK = true;
+                }
+                
+            }
+            catch
+            {
+                parsedOK = false;
+            }
+
+            return parsedOK;
+        }
+
+        internal static bool IsSupported(int resolution)
+        {
+            return IsSupported(resolution.ToString());
+        }
+
+        internal static bool IsSupported(string resolution)
+        {
+            eSupportedResolution res;
+            if (!Enum.TryParse(resolution, true, out res))
+            {
+                return false;
+            }
+
+            if(!Enum.IsDefined(typeof(eSupportedResolution), res))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        [DllImport("user32.dll")]
+        internal static extern bool EnumDisplaySettings(
+              string deviceName, int modeNum, ref DEVMODE devMode);
+        const int ENUM_CURRENT_SETTINGS = -1;
+
+        const int ENUM_REGISTRY_SETTINGS = -2;
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct DEVMODE
+        {
+            private const int CCHDEVICENAME = 0x20;
+            private const int CCHFORMNAME = 0x20;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+            public string dmDeviceName;
+            public short dmSpecVersion;
+            public short dmDriverVersion;
+            public short dmSize;
+            public short dmDriverExtra;
+            public int dmFields;
+            public int dmPositionX;
+            public int dmPositionY;
+            public ScreenOrientation dmDisplayOrientation;
+            public int dmDisplayFixedOutput;
+            public short dmColor;
+            public short dmDuplex;
+            public short dmYResolution;
+            public short dmTTOption;
+            public short dmCollate;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
+            public string dmFormName;
+            public short dmLogPixels;
+            public int dmBitsPerPel;
+            public int dmPelsWidth;
+            public int dmPelsHeight;
+            public int dmDisplayFlags;
+            public int dmDisplayFrequency;
+            public int dmICMMethod;
+            public int dmICMIntent;
+            public int dmMediaType;
+            public int dmDitherType;
+            public int dmReserved1;
+            public int dmReserved2;
+            public int dmPanningWidth;
+            public int dmPanningHeight;
+        }
+    }
+}

--- a/Client/Resolution/eSupportedResolution.cs
+++ b/Client/Resolution/eSupportedResolution.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Client.Resolution
+{
+    public enum eSupportedResolution
+    {
+        w1024h768 = 1024,
+        w1280h720 = 1280,
+        w1366h768 = 1366,
+        w1920h1080 = 1920
+    }
+}


### PR DESCRIPTION
Patcher settings will not allow a non-supported display resolution to be chosen.
If client tries to start with an unsupported display resolution then a msgbox will inform the user the resolution will be set to 1024768.  This works in both patcher and patcher bypass mode