### PR TITLE
Maintain 800 resolution

### DIFF
--- a/Client/MirScenes/Dialogs/HeroDialogs.cs
+++ b/Client/MirScenes/Dialogs/HeroDialogs.cs
@@ -392,9 +392,14 @@ namespace Client.MirScenes.Dialogs
             Library = Libraries.Prguse;
             Size = new Size(24, 61);
             Parent = parent;
-
-            Location = new Point(((Settings.ScreenWidth / 2) - (Size.Width / 2)) + 362, Settings.ScreenHeight - Size.Height - 77);
-
+            if (GameScene.Scene.Size.Width < 1024)
+            {
+                Location = new Point(639, 464);
+            }
+            else
+            {
+                Location = new Point(((Settings.ScreenWidth / 2) - (Size.Width / 2)) + 362, Settings.ScreenHeight - Size.Height - 77);
+            }
             HeroMagicsButton = new MirButton
             {
                 Index = 2173,

--- a/Client/MirScenes/SelectScene.cs
+++ b/Client/MirScenes/SelectScene.cs
@@ -472,6 +472,9 @@ namespace Client.MirScenes
                     switch (Settings.Resolution)
                     {
                         default:
+                        case 800:
+                            CMain.SetResolution(800, 600);
+                            break;
                         case 1024:
                             Settings.Resolution = 1024;
                             CMain.SetResolution(1024, 768);

--- a/Client/Resolution/eSupportedResolution.cs
+++ b/Client/Resolution/eSupportedResolution.cs
@@ -8,6 +8,7 @@ namespace Client.Resolution
 {
     public enum eSupportedResolution
     {
+        w800h600=800,
         w1024h768 = 1024,
         w1280h720 = 1280,
         w1366h768 = 1366,


### PR DESCRIPTION
1. Fixed the dislocation of the hero's 800 resolution and used the IF statement to solve the conflict between 1024 resolution and 800 resolution
2,800 resolution is a nostalgic resolution, and its effect has an irreplaceable position among the old MIR players for many years