### PR TITLE
Fixes for cross-platform support

### DIFF
--- a/Server/MirDatabase/CharacterInfo.cs
+++ b/Server/MirDatabase/CharacterInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 using Server.MirNetwork;
 using Server.MirObjects;

--- a/Server/MirDatabase/ConquestInfo.cs
+++ b/Server/MirDatabase/ConquestInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 
 namespace Server.MirDatabase

--- a/Server/MirDatabase/DragonInfo.cs
+++ b/Server/MirDatabase/DragonInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 
 namespace Server.MirDatabase

--- a/Server/MirDatabase/GuildInfo.cs
+++ b/Server/MirDatabase/GuildInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 using Server.MirObjects;
 

--- a/Server/MirDatabase/MapInfo.cs
+++ b/Server/MirDatabase/MapInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using Server.MirEnvir;
 
 namespace Server.MirDatabase

--- a/Server/MirDatabase/MineInfo.cs
+++ b/Server/MirDatabase/MineInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿namespace Server.MirDatabase
 {
     public class MineSet

--- a/Server/MirDatabase/MovementInfo.cs
+++ b/Server/MirDatabase/MovementInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 
 namespace Server.MirDatabase

--- a/Server/MirDatabase/NPCInfo.cs
+++ b/Server/MirDatabase/NPCInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 
 namespace Server.MirDatabase

--- a/Server/MirDatabase/RespawnInfo.cs
+++ b/Server/MirDatabase/RespawnInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using Server.MirEnvir;
 
 namespace Server.MirDatabase

--- a/Server/MirDatabase/SafeZoneInfo.cs
+++ b/Server/MirDatabase/SafeZoneInfo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿namespace Server.MirDatabase
 {
     public class SafeZoneInfo

--- a/Server/MirEnvir/Dragon.cs
+++ b/Server/MirEnvir/Dragon.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirObjects;
 using Server.MirObjects.Monsters;

--- a/Server/MirEnvir/Map.cs
+++ b/Server/MirEnvir/Map.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirObjects;
 using S = ServerPackets;

--- a/Server/MirObjects/ConquestObject.cs
+++ b/Server/MirObjects/ConquestObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 using Server.MirDatabase;
 

--- a/Server/MirObjects/DecoObject.cs
+++ b/Server/MirObjects/DecoObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 using S = ServerPackets;
 

--- a/Server/MirObjects/HeroObject.cs
+++ b/Server/MirObjects/HeroObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using Server.MirNetwork;

--- a/Server/MirObjects/HumanObject.cs
+++ b/Server/MirObjects/HumanObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using Server.MirNetwork;

--- a/Server/MirObjects/IntelligentCreatureObject.cs
+++ b/Server/MirObjects/IntelligentCreatureObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/ItemObject.cs
+++ b/Server/MirObjects/ItemObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/MapObject.cs
+++ b/Server/MirObjects/MapObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using Server.MirObjects.Monsters;

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using Server.MirObjects.Monsters;

--- a/Server/MirObjects/Monsters/AncientBringer.cs
+++ b/Server/MirObjects/Monsters/AncientBringer.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/Armadillo.cs
+++ b/Server/MirObjects/Monsters/Armadillo.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/Behemoth.cs
+++ b/Server/MirObjects/Monsters/Behemoth.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/CannibalTentacles.cs
+++ b/Server/MirObjects/Monsters/CannibalTentacles.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/CastleGate.cs
+++ b/Server/MirObjects/Monsters/CastleGate.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 

--- a/Server/MirObjects/Monsters/CrystalSpider.cs
+++ b/Server/MirObjects/Monsters/CrystalSpider.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/DarkCaptain.cs
+++ b/Server/MirObjects/Monsters/DarkCaptain.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/DarkOmaKing.cs
+++ b/Server/MirObjects/Monsters/DarkOmaKing.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/DarkWraith.cs
+++ b/Server/MirObjects/Monsters/DarkWraith.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/DigOutZombie.cs
+++ b/Server/MirObjects/Monsters/DigOutZombie.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/Doe.cs
+++ b/Server/MirObjects/Monsters/Doe.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 

--- a/Server/MirObjects/Monsters/EarthGolem.cs
+++ b/Server/MirObjects/Monsters/EarthGolem.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/FloatingRock.cs
+++ b/Server/MirObjects/Monsters/FloatingRock.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/FlyingStatue.cs
+++ b/Server/MirObjects/Monsters/FlyingStatue.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/Football.cs
+++ b/Server/MirObjects/Monsters/Football.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 
 namespace Server.MirObjects.Monsters

--- a/Server/MirObjects/Monsters/FurbolgArcher.cs
+++ b/Server/MirObjects/Monsters/FurbolgArcher.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/FurbolgGuard.cs
+++ b/Server/MirObjects/Monsters/FurbolgGuard.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/FurbolgWarrior.cs
+++ b/Server/MirObjects/Monsters/FurbolgWarrior.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/Gate.cs
+++ b/Server/MirObjects/Monsters/Gate.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/Guard.cs
+++ b/Server/MirObjects/Monsters/Guard.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/HellLord.cs
+++ b/Server/MirObjects/Monsters/HellLord.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/HornedCommander.cs
+++ b/Server/MirObjects/Monsters/HornedCommander.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/HornedMage.cs
+++ b/Server/MirObjects/Monsters/HornedMage.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/HornedSorceror.cs
+++ b/Server/MirObjects/Monsters/HornedSorceror.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/HumanAssassin.cs
+++ b/Server/MirObjects/Monsters/HumanAssassin.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/Khazard.cs
+++ b/Server/MirObjects/Monsters/Khazard.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/KingScorpion.cs
+++ b/Server/MirObjects/Monsters/KingScorpion.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/Kirin.cs
+++ b/Server/MirObjects/Monsters/Kirin.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/ManTree.cs
+++ b/Server/MirObjects/Monsters/ManTree.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/ManectricBlest.cs
+++ b/Server/MirObjects/Monsters/ManectricBlest.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/ManectricClaw.cs
+++ b/Server/MirObjects/Monsters/ManectricClaw.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/PowerBead.cs
+++ b/Server/MirObjects/Monsters/PowerBead.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/RedFoxman.cs
+++ b/Server/MirObjects/Monsters/RedFoxman.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/RootSpider.cs
+++ b/Server/MirObjects/Monsters/RootSpider.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/SepHighWizard.cs
+++ b/Server/MirObjects/Monsters/SepHighWizard.cs
@@ -30,8 +30,6 @@ namespace Server.MirObjects.Monsters
                 return;
             }
 
-            DelayedAction action;
-
             ShockTime = 0;
             ActionTime = Envir.Time + 300;
             AttackTime = Envir.Time + AttackSpeed;

--- a/Server/MirObjects/Monsters/StoneGolem.cs
+++ b/Server/MirObjects/Monsters/StoneGolem.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/StrayCat.cs
+++ b/Server/MirObjects/Monsters/StrayCat.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/TrapRock.cs
+++ b/Server/MirObjects/Monsters/TrapRock.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 

--- a/Server/MirObjects/Monsters/TreeQueen.cs
+++ b/Server/MirObjects/Monsters/TreeQueen.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/TucsonGeneral.cs
+++ b/Server/MirObjects/Monsters/TucsonGeneral.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/TucsonMage.cs
+++ b/Server/MirObjects/Monsters/TucsonMage.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/TurtleKing.cs
+++ b/Server/MirObjects/Monsters/TurtleKing.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using S = ServerPackets;
 using Server.MirEnvir;

--- a/Server/MirObjects/Monsters/VampireSpider.cs
+++ b/Server/MirObjects/Monsters/VampireSpider.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/WingedTigerLord.cs
+++ b/Server/MirObjects/Monsters/WingedTigerLord.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/WitchDoctor.cs
+++ b/Server/MirObjects/Monsters/WitchDoctor.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/WoomaTaurus.cs
+++ b/Server/MirObjects/Monsters/WoomaTaurus.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 

--- a/Server/MirObjects/Monsters/Yimoogi.cs
+++ b/Server/MirObjects/Monsters/Yimoogi.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/Monsters/ZumaMonster.cs
+++ b/Server/MirObjects/Monsters/ZumaMonster.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/NPC/NPCScript.cs
+++ b/Server/MirObjects/NPC/NPCScript.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using System.Text.RegularExpressions;

--- a/Server/MirObjects/NPC/NPCSegment.cs
+++ b/Server/MirObjects/NPC/NPCSegment.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using System.Globalization;

--- a/Server/MirObjects/NPCObject.cs
+++ b/Server/MirObjects/NPCObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using C = ClientPackets;
 using Server.MirDatabase;
 using Server.MirEnvir;

--- a/Server/MirObjects/SpellObject.cs
+++ b/Server/MirObjects/SpellObject.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 ﻿using Server.MirEnvir;
 using S = ServerPackets;
 

--- a/Server/Server.Library.csproj
+++ b/Server/Server.Library.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>disable</Nullable>
-    <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 


### PR DESCRIPTION
# Overview

This pull request adds support for building the Server library on Linux. It seems that for whatever reason `net7.0-win` automatically imports `System.Drawing`, which is required for the `Point` struct used in a lot of the changed files below. The Server library also doesn't contain any WinForms code, so those can be disabled.

I've successfully built the server on both Windows and Linux.

## Windows build output

This is the full Server.MirForms application:

![image](https://github.com/Suprcode/mir2/assets/2040110/d951ba81-21fa-41f1-a86c-6ffc69c13de7)

And just to demonstrate the Windows build is still working correctly (ignore the map errors, I'm working with a random assortment I found on an old PC):

![image](https://github.com/Suprcode/mir2/assets/2040110/3191ddbe-990e-4cca-b553-b6cae174eb44)

## Linux build output

This is just the Server library:

![image](https://github.com/Suprcode/mir2/assets/2040110/21d5b075-a3de-4917-adc9-d7d01a78af48)

# Changelog

## Changed

* The Server library now targets `net7.0` instead of `net7.0-win`.
* The Server library no longer requires WinForms to build.

## Fixed

* Restored `System.Drawing` imports in files which use the `Point` struct.
* Removed an unused variable.