### PR TITLE
QOL Failed to load map.

### DIFF
--- a/Server/MirEnvir/Map.cs
+++ b/Server/MirEnvir/Map.cs
@@ -507,7 +507,8 @@ namespace Server.MirEnvir
                 MessageQueue.Enqueue(ex);
             }
 
-            MessageQueue.Enqueue("Failed to Load Map: " + Info.FileName);
+            MessageQueue.Enqueue("Failed to Load Map: " + Info.Title);
+            MessageQueue.Enqueue("Filename: " + Info.FileName);
             return false;
         }
 


### PR DESCRIPTION
QOL Addition to include missing map's Name.

Old: Only displayed Filename (Made it difficult as you needed to locate which map in the database had that filename)