### PR TITLE
Player info form

### DIFF
--- a/Server.MirForms/Account/AccountInfoForm.Designer.cs
+++ b/Server.MirForms/Account/AccountInfoForm.Designer.cs
@@ -40,6 +40,7 @@ namespace Server
             characterLevel = new ColumnHeader();
             characterPKPoints = new ColumnHeader();
             characterGuild = new ColumnHeader();
+            characterStatus = new ColumnHeader();
             LastIPSearch = new Button();
             CreationIPSearch = new Button();
             PasswordChangeCheckBox = new CheckBox();
@@ -84,10 +85,10 @@ namespace Server
             bannedHeader = new ColumnHeader();
             banReasonHeader = new ColumnHeader();
             expiryDateHeader = new ColumnHeader();
-            MatchFilterCheckBox = new CheckBox();
-            WipeCharButton = new Button();
             Gold = new ColumnHeader();
             GameGold = new ColumnHeader();
+            MatchFilterCheckBox = new CheckBox();
+            WipeCharButton = new Button();
             AccountInfoPanel.SuspendLayout();
             SuspendLayout();
             // 
@@ -172,17 +173,17 @@ namespace Server
             AccountInfoPanel.Location = new Point(14, 277);
             AccountInfoPanel.Margin = new Padding(4, 3, 4, 3);
             AccountInfoPanel.Name = "AccountInfoPanel";
-            AccountInfoPanel.Size = new Size(1073, 243);
+            AccountInfoPanel.Size = new Size(1248, 243);
             AccountInfoPanel.TabIndex = 14;
             // 
             // CharactersListView
             // 
-            CharactersListView.Columns.AddRange(new ColumnHeader[] { characterName, characterClass, characterLevel, characterPKPoints, characterGuild });
+            CharactersListView.Columns.AddRange(new ColumnHeader[] { characterName, characterClass, characterLevel, characterPKPoints, characterGuild, characterStatus });
             CharactersListView.GridLines = true;
             CharactersListView.Location = new Point(701, 0);
             CharactersListView.Name = "CharactersListView";
             CharactersListView.Scrollable = false;
-            CharactersListView.Size = new Size(371, 163);
+            CharactersListView.Size = new Size(546, 163);
             CharactersListView.TabIndex = 39;
             CharactersListView.UseCompatibleStateImageBehavior = false;
             CharactersListView.View = View.Details;
@@ -209,7 +210,12 @@ namespace Server
             // characterGuild
             // 
             characterGuild.Text = "Guild";
-            characterGuild.Width = 90;
+            characterGuild.Width = 100;
+            // 
+            // characterStatus
+            // 
+            characterStatus.Text = "Status";
+            characterStatus.Width = 163;
             // 
             // LastIPSearch
             // 
@@ -577,7 +583,7 @@ namespace Server
             AccountInfoListView.Location = new Point(12, 75);
             AccountInfoListView.Margin = new Padding(4, 3, 4, 3);
             AccountInfoListView.Name = "AccountInfoListView";
-            AccountInfoListView.Size = new Size(1074, 194);
+            AccountInfoListView.Size = new Size(1249, 194);
             AccountInfoListView.Sorting = SortOrder.Ascending;
             AccountInfoListView.TabIndex = 8;
             AccountInfoListView.UseCompatibleStateImageBehavior = false;
@@ -618,6 +624,16 @@ namespace Server
             expiryDateHeader.Text = "Expiry Date";
             expiryDateHeader.Width = 81;
             // 
+            // Gold
+            // 
+            Gold.Text = "Gold";
+            Gold.Width = 100;
+            // 
+            // GameGold
+            // 
+            GameGold.Text = "GameGold";
+            GameGold.Width = 70;
+            // 
             // MatchFilterCheckBox
             // 
             MatchFilterCheckBox.AutoSize = true;
@@ -640,21 +656,11 @@ namespace Server
             WipeCharButton.UseVisualStyleBackColor = true;
             WipeCharButton.Click += WipeCharButton_Click;
             // 
-            // Gold
-            // 
-            Gold.Text = "Gold";
-            Gold.Width = 90;
-            // 
-            // GameGold
-            // 
-            GameGold.Text = "GameGold";
-            GameGold.Width = 70;
-            // 
             // AccountInfoForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(1101, 532);
+            ClientSize = new Size(1276, 532);
             Controls.Add(WipeCharButton);
             Controls.Add(MatchFilterCheckBox);
             Controls.Add(FilterPlayerTextBox);
@@ -736,5 +742,6 @@ namespace Server
         private ColumnHeader characterGuild;
         private ColumnHeader Gold;
         private ColumnHeader GameGold;
+        private ColumnHeader characterStatus;
     }
 }

--- a/Server.MirForms/Account/AccountInfoForm.Designer.cs
+++ b/Server.MirForms/Account/AccountInfoForm.Designer.cs
@@ -89,6 +89,10 @@ namespace Server
             GameGold = new ColumnHeader();
             MatchFilterCheckBox = new CheckBox();
             WipeCharButton = new Button();
+            ServerGoldTextBox = new TextBox();
+            TotalServerGold = new Label();
+            ServerCreditTextBox = new TextBox();
+            TotalServerCredit = new Label();
             AccountInfoPanel.SuspendLayout();
             SuspendLayout();
             // 
@@ -656,11 +660,49 @@ namespace Server
             WipeCharButton.UseVisualStyleBackColor = true;
             WipeCharButton.Click += WipeCharButton_Click;
             // 
+            // ServerGoldTextBox
+            // 
+            ServerGoldTextBox.Location = new Point(356, 16);
+            ServerGoldTextBox.Name = "ServerGoldTextBox";
+            ServerGoldTextBox.ReadOnly = true;
+            ServerGoldTextBox.Size = new Size(153, 23);
+            ServerGoldTextBox.TabIndex = 22;
+            // 
+            // TotalServerGold
+            // 
+            TotalServerGold.AutoSize = true;
+            TotalServerGold.Location = new Point(252, 19);
+            TotalServerGold.Name = "TotalServerGold";
+            TotalServerGold.Size = new Size(98, 15);
+            TotalServerGold.TabIndex = 21;
+            TotalServerGold.Text = "Total Server Gold:";
+            // 
+            // ServerCreditTextBox
+            // 
+            ServerCreditTextBox.Location = new Point(624, 19);
+            ServerCreditTextBox.Name = "ServerCreditTextBox";
+            ServerCreditTextBox.ReadOnly = true;
+            ServerCreditTextBox.Size = new Size(153, 23);
+            ServerCreditTextBox.TabIndex = 24;
+            // 
+            // TotalServerCredit
+            // 
+            TotalServerCredit.AutoSize = true;
+            TotalServerCredit.Location = new Point(520, 22);
+            TotalServerCredit.Name = "TotalServerCredit";
+            TotalServerCredit.Size = new Size(105, 15);
+            TotalServerCredit.TabIndex = 23;
+            TotalServerCredit.Text = "Total Server Credit:";
+            // 
             // AccountInfoForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(1276, 532);
+            Controls.Add(ServerCreditTextBox);
+            Controls.Add(TotalServerCredit);
+            Controls.Add(ServerGoldTextBox);
+            Controls.Add(TotalServerGold);
             Controls.Add(WipeCharButton);
             Controls.Add(MatchFilterCheckBox);
             Controls.Add(FilterPlayerTextBox);
@@ -743,5 +785,9 @@ namespace Server
         private ColumnHeader Gold;
         private ColumnHeader GameGold;
         private ColumnHeader characterStatus;
+        private TextBox ServerGoldTextBox;
+        private Label TotalServerGold;
+        private TextBox ServerCreditTextBox;
+        private Label TotalServerCredit;
     }
 }

--- a/Server.MirForms/Account/AccountInfoForm.cs
+++ b/Server.MirForms/Account/AccountInfoForm.cs
@@ -1,6 +1,7 @@
 ﻿using Server.MirDatabase;
 using Server.MirEnvir;
 using Server.MirObjects;
+using System.Globalization;
 
 namespace Server
 {
@@ -90,6 +91,27 @@ namespace Server
             }
 
             List<AccountInfo> accounts = SMain.Envir.AccountList;
+
+            long totalgold = 0;
+            foreach (var account in accounts)
+            {
+                if (!account.AdminAccount && !account.Banned)
+                    totalgold += account.Gold;
+                ServerGoldTextBox.Text = totalgold.ToString();
+            }
+            CultureInfo culture = new CultureInfo("en-GB");
+            string formattedgold = totalgold.ToString("N0", culture);
+            ServerGoldTextBox.Text = formattedgold;
+
+            long totalcredit = 0;
+            foreach (var account in accounts)
+            {
+                if (!account.AdminAccount && !account.Banned)
+                    totalcredit += account.Credit;
+                ServerCreditTextBox.Text = totalcredit.ToString();
+            }
+            string formattedcredit = totalcredit.ToString("N0", culture);
+            ServerCreditTextBox.Text = formattedcredit;
 
             if (FilterTextBox.Text.Length > 0)
                 accounts = SMain.Envir.MatchAccounts(FilterTextBox.Text, MatchFilterCheckBox.Checked);

--- a/Server.MirForms/Account/AccountInfoForm.cs
+++ b/Server.MirForms/Account/AccountInfoForm.cs
@@ -92,26 +92,18 @@ namespace Server
 
             List<AccountInfo> accounts = SMain.Envir.AccountList;
 
-            long totalgold = 0;
-            foreach (var account in accounts)
-            {
-                if (!account.AdminAccount && !account.Banned)
-                    totalgold += account.Gold;
-                ServerGoldTextBox.Text = totalgold.ToString();
-            }
-            CultureInfo culture = new CultureInfo("en-GB");
-            string formattedgold = totalgold.ToString("N0", culture);
-            ServerGoldTextBox.Text = formattedgold;
+            long totalGold = accounts
+            .Where(account => !account.AdminAccount && !account.Banned)
+            .Sum(account => account.Gold);
 
-            long totalcredit = 0;
-            foreach (var account in accounts)
-            {
-                if (!account.AdminAccount && !account.Banned)
-                    totalcredit += account.Credit;
-                ServerCreditTextBox.Text = totalcredit.ToString();
-            }
-            string formattedcredit = totalcredit.ToString("N0", culture);
-            ServerCreditTextBox.Text = formattedcredit;
+            ServerGoldTextBox.Text = totalGold.ToString("N0", CultureInfo.GetCultureInfo("en-GB"));
+
+
+            long totalCredit = accounts
+            .Where(account => !account.AdminAccount && !account.Banned)
+            .Sum(account => account.Credit);
+
+            ServerCreditTextBox.Text = totalCredit.ToString("N0", CultureInfo.GetCultureInfo("en-GB"));
 
             if (FilterTextBox.Text.Length > 0)
                 accounts = SMain.Envir.MatchAccounts(FilterTextBox.Text, MatchFilterCheckBox.Checked);

--- a/Server.MirForms/Account/AccountInfoForm.cs
+++ b/Server.MirForms/Account/AccountInfoForm.cs
@@ -202,6 +202,30 @@ namespace Server
                             listItem.SubItems.Add(guild.Name.ToString());
                         }
                     }
+                    else
+                    {
+                        listItem.SubItems.Add("No Guild");
+                    }
+
+                    string status = $"";
+
+                    if (character.LastLoginDate > character.LastLogoutDate)
+                    {
+                        status = $"Online: {(SMain.Envir.Now - character.LastLoginDate).TotalMinutes.ToString("##")} minutes";
+                        listItem.ForeColor = Color.Green;
+                    }
+                    else
+                    {
+                        status = $"Offline: {character.LastLogoutDate}";
+                    }
+
+                    if (character.Deleted)
+                    {
+                        status = $"Deleted: {character.DeleteDate}";
+                        listItem.ForeColor = Color.Red;
+                    }
+
+                    listItem.SubItems.Add(status.ToString());
 
                     CharactersListView.Items.Add(listItem);
                 }

--- a/Server.MirForms/Account/PlayerInfoForm.Designer.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.Designer.cs
@@ -39,6 +39,23 @@
             SendMessageTextBox = new TextBox();
             SendMessageButton = new Button();
             groupBox1 = new GroupBox();
+            ATKSPDBox = new TextBox();
+            AGILBox = new TextBox();
+            ACCBox = new TextBox();
+            SCBox = new TextBox();
+            MCBox = new TextBox();
+            DCBox = new TextBox();
+            AMCBox = new TextBox();
+            ACBox = new TextBox();
+            StatsLabel = new Label();
+            GameGold = new Label();
+            GameGoldTextBox = new TextBox();
+            Gold = new Label();
+            GoldTextBox = new TextBox();
+            PKPoints = new Label();
+            PKPointsTextBox = new TextBox();
+            label12 = new Label();
+            ExpTextBox = new TextBox();
             groupBox2 = new GroupBox();
             OpenAccountButton = new Button();
             SafeZoneButton = new Button();
@@ -56,33 +73,32 @@
             CurrentIPLabel = new Label();
             groupBox4 = new GroupBox();
             ResultLabel = new Label();
-            FlagSearchBox = new TextBox();
             FlagSearch = new Label();
-            FlagUp = new Button();
-            FlagDown = new Button();
-            QuestDown = new Button();
-            QuestUp = new Button();
             QuestResultLabel = new Label();
-            QuestSearchBox = new TextBox();
             label10 = new Label();
-            GameGold = new Label();
-            GameGoldTextBox = new TextBox();
-            Gold = new Label();
-            GoldTextBox = new TextBox();
-            PKPoints = new Label();
-            PKPointsTextBox = new TextBox();
-            label12 = new Label();
-            ExpTextBox = new TextBox();
+            SearchBox = new GroupBox();
+            FlagSearchBox = new NumericUpDown();
+            QuestSearchBox = new NumericUpDown();
+            PetView = new ListView();
+            Pet = new ColumnHeader();
+            Level = new ColumnHeader();
+            HP = new ColumnHeader();
+            Location = new ColumnHeader();
+            Pets = new GroupBox();
             groupBox1.SuspendLayout();
             groupBox2.SuspendLayout();
             groupBox3.SuspendLayout();
             groupBox4.SuspendLayout();
+            SearchBox.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)FlagSearchBox).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)QuestSearchBox).BeginInit();
+            Pets.SuspendLayout();
             SuspendLayout();
             // 
             // label1
             // 
             label1.AutoSize = true;
-            label1.Location = new Point(8, 53);
+            label1.Location = new Point(10, 53);
             label1.Margin = new Padding(4, 0, 4, 0);
             label1.Name = "label1";
             label1.Size = new Size(48, 15);
@@ -136,7 +152,7 @@
             // 
             // UpdateButton
             // 
-            UpdateButton.Location = new Point(108, 238);
+            UpdateButton.Location = new Point(86, 227);
             UpdateButton.Margin = new Padding(4, 3, 4, 3);
             UpdateButton.Name = "UpdateButton";
             UpdateButton.Size = new Size(88, 27);
@@ -161,12 +177,12 @@
             SendMessageTextBox.Location = new Point(7, 22);
             SendMessageTextBox.Margin = new Padding(4, 3, 4, 3);
             SendMessageTextBox.Name = "SendMessageTextBox";
-            SendMessageTextBox.Size = new Size(347, 23);
+            SendMessageTextBox.Size = new Size(244, 23);
             SendMessageTextBox.TabIndex = 9;
             // 
             // SendMessageButton
             // 
-            SendMessageButton.Location = new Point(362, 20);
+            SendMessageButton.Location = new Point(266, 22);
             SendMessageButton.Margin = new Padding(4, 3, 4, 3);
             SendMessageButton.Name = "SendMessageButton";
             SendMessageButton.Size = new Size(68, 27);
@@ -177,6 +193,15 @@
             // 
             // groupBox1
             // 
+            groupBox1.Controls.Add(ATKSPDBox);
+            groupBox1.Controls.Add(AGILBox);
+            groupBox1.Controls.Add(ACCBox);
+            groupBox1.Controls.Add(SCBox);
+            groupBox1.Controls.Add(MCBox);
+            groupBox1.Controls.Add(DCBox);
+            groupBox1.Controls.Add(AMCBox);
+            groupBox1.Controls.Add(ACBox);
+            groupBox1.Controls.Add(StatsLabel);
             groupBox1.Controls.Add(GameGold);
             groupBox1.Controls.Add(GameGoldTextBox);
             groupBox1.Controls.Add(Gold);
@@ -196,10 +221,173 @@
             groupBox1.Margin = new Padding(4, 3, 4, 3);
             groupBox1.Name = "groupBox1";
             groupBox1.Padding = new Padding(4, 3, 4, 3);
-            groupBox1.Size = new Size(196, 265);
+            groupBox1.Size = new Size(341, 265);
             groupBox1.TabIndex = 11;
             groupBox1.TabStop = false;
             groupBox1.Text = "Character Info";
+            // 
+            // ATKSPDBox
+            // 
+            ATKSPDBox.Enabled = false;
+            ATKSPDBox.Location = new Point(261, 229);
+            ATKSPDBox.Margin = new Padding(4, 3, 4, 3);
+            ATKSPDBox.Name = "ATKSPDBox";
+            ATKSPDBox.ReadOnly = true;
+            ATKSPDBox.Size = new Size(73, 23);
+            ATKSPDBox.TabIndex = 32;
+            // 
+            // AGILBox
+            // 
+            AGILBox.Enabled = false;
+            AGILBox.Location = new Point(261, 200);
+            AGILBox.Margin = new Padding(4, 3, 4, 3);
+            AGILBox.Name = "AGILBox";
+            AGILBox.ReadOnly = true;
+            AGILBox.Size = new Size(73, 23);
+            AGILBox.TabIndex = 31;
+            // 
+            // ACCBox
+            // 
+            ACCBox.Enabled = false;
+            ACCBox.Location = new Point(261, 168);
+            ACCBox.Margin = new Padding(4, 3, 4, 3);
+            ACCBox.Name = "ACCBox";
+            ACCBox.ReadOnly = true;
+            ACCBox.Size = new Size(73, 23);
+            ACCBox.TabIndex = 30;
+            // 
+            // SCBox
+            // 
+            SCBox.Enabled = false;
+            SCBox.Location = new Point(261, 139);
+            SCBox.Margin = new Padding(4, 3, 4, 3);
+            SCBox.Name = "SCBox";
+            SCBox.ReadOnly = true;
+            SCBox.Size = new Size(73, 23);
+            SCBox.TabIndex = 29;
+            // 
+            // MCBox
+            // 
+            MCBox.Enabled = false;
+            MCBox.Location = new Point(261, 110);
+            MCBox.Margin = new Padding(4, 3, 4, 3);
+            MCBox.Name = "MCBox";
+            MCBox.ReadOnly = true;
+            MCBox.Size = new Size(73, 23);
+            MCBox.TabIndex = 28;
+            // 
+            // DCBox
+            // 
+            DCBox.Enabled = false;
+            DCBox.Location = new Point(261, 81);
+            DCBox.Margin = new Padding(4, 3, 4, 3);
+            DCBox.Name = "DCBox";
+            DCBox.ReadOnly = true;
+            DCBox.Size = new Size(73, 23);
+            DCBox.TabIndex = 27;
+            // 
+            // AMCBox
+            // 
+            AMCBox.Enabled = false;
+            AMCBox.Location = new Point(261, 49);
+            AMCBox.Margin = new Padding(4, 3, 4, 3);
+            AMCBox.Name = "AMCBox";
+            AMCBox.ReadOnly = true;
+            AMCBox.Size = new Size(73, 23);
+            AMCBox.TabIndex = 26;
+            // 
+            // ACBox
+            // 
+            ACBox.Enabled = false;
+            ACBox.Location = new Point(261, 20);
+            ACBox.Margin = new Padding(4, 3, 4, 3);
+            ACBox.Name = "ACBox";
+            ACBox.ReadOnly = true;
+            ACBox.Size = new Size(73, 23);
+            ACBox.TabIndex = 24;
+            // 
+            // StatsLabel
+            // 
+            StatsLabel.AutoSize = true;
+            StatsLabel.Location = new Point(197, 23);
+            StatsLabel.Margin = new Padding(4, 0, 4, 0);
+            StatsLabel.Name = "StatsLabel";
+            StatsLabel.Size = new Size(54, 225);
+            StatsLabel.TabIndex = 25;
+            StatsLabel.Text = "AC:\r\n\r\nAMC:\r\n\r\nDC:\r\n\r\nMC:\r\n\r\nSC:\r\n\r\nACC:\r\n\r\nAGIL:\r\n\r\nATK SPD:";
+            // 
+            // GameGold
+            // 
+            GameGold.AutoSize = true;
+            GameGold.Font = new Font("Segoe UI", 8F);
+            GameGold.Location = new Point(10, 201);
+            GameGold.Margin = new Padding(4, 0, 4, 0);
+            GameGold.Name = "GameGold";
+            GameGold.Size = new Size(52, 13);
+            GameGold.TabIndex = 22;
+            GameGold.Text = "Credits : ";
+            // 
+            // GameGoldTextBox
+            // 
+            GameGoldTextBox.Location = new Point(70, 198);
+            GameGoldTextBox.Margin = new Padding(4, 3, 4, 3);
+            GameGoldTextBox.Name = "GameGoldTextBox";
+            GameGoldTextBox.Size = new Size(116, 23);
+            GameGoldTextBox.TabIndex = 23;
+            // 
+            // Gold
+            // 
+            Gold.AutoSize = true;
+            Gold.Location = new Point(10, 172);
+            Gold.Margin = new Padding(4, 0, 4, 0);
+            Gold.Name = "Gold";
+            Gold.Size = new Size(41, 15);
+            Gold.TabIndex = 20;
+            Gold.Text = "Gold : ";
+            // 
+            // GoldTextBox
+            // 
+            GoldTextBox.Location = new Point(70, 169);
+            GoldTextBox.Margin = new Padding(4, 3, 4, 3);
+            GoldTextBox.Name = "GoldTextBox";
+            GoldTextBox.Size = new Size(116, 23);
+            GoldTextBox.TabIndex = 21;
+            // 
+            // PKPoints
+            // 
+            PKPoints.AutoSize = true;
+            PKPoints.Location = new Point(10, 143);
+            PKPoints.Margin = new Padding(4, 0, 4, 0);
+            PKPoints.Name = "PKPoints";
+            PKPoints.Size = new Size(58, 15);
+            PKPoints.TabIndex = 18;
+            PKPoints.Text = "PKPoint : ";
+            // 
+            // PKPointsTextBox
+            // 
+            PKPointsTextBox.Location = new Point(70, 140);
+            PKPointsTextBox.Margin = new Padding(4, 3, 4, 3);
+            PKPointsTextBox.Name = "PKPointsTextBox";
+            PKPointsTextBox.Size = new Size(116, 23);
+            PKPointsTextBox.TabIndex = 19;
+            // 
+            // label12
+            // 
+            label12.AutoSize = true;
+            label12.Location = new Point(10, 114);
+            label12.Margin = new Padding(4, 0, 4, 0);
+            label12.Name = "label12";
+            label12.Size = new Size(36, 15);
+            label12.TabIndex = 16;
+            label12.Text = "EXP : ";
+            // 
+            // ExpTextBox
+            // 
+            ExpTextBox.Location = new Point(70, 111);
+            ExpTextBox.Margin = new Padding(4, 3, 4, 3);
+            ExpTextBox.Name = "ExpTextBox";
+            ExpTextBox.Size = new Size(116, 23);
+            ExpTextBox.TabIndex = 17;
             // 
             // groupBox2
             // 
@@ -211,7 +399,7 @@
             groupBox2.Controls.Add(KillPetsButton);
             groupBox2.Controls.Add(KillButton);
             groupBox2.Controls.Add(KickButton);
-            groupBox2.Location = new Point(210, 14);
+            groupBox2.Location = new Point(356, 14);
             groupBox2.Margin = new Padding(4, 3, 4, 3);
             groupBox2.Name = "groupBox2";
             groupBox2.Padding = new Padding(4, 3, 4, 3);
@@ -298,11 +486,11 @@
             // 
             groupBox3.Controls.Add(SendMessageTextBox);
             groupBox3.Controls.Add(SendMessageButton);
-            groupBox3.Location = new Point(7, 365);
+            groupBox3.Location = new Point(8, 386);
             groupBox3.Margin = new Padding(4, 3, 4, 3);
             groupBox3.Name = "groupBox3";
             groupBox3.Padding = new Padding(4, 3, 4, 3);
-            groupBox3.Size = new Size(436, 57);
+            groupBox3.Size = new Size(341, 57);
             groupBox3.TabIndex = 13;
             groupBox3.TabStop = false;
             groupBox3.Text = "Send Message";
@@ -380,7 +568,7 @@
             groupBox4.Margin = new Padding(4, 3, 4, 3);
             groupBox4.Name = "groupBox4";
             groupBox4.Padding = new Padding(4, 3, 4, 3);
-            groupBox4.Size = new Size(364, 74);
+            groupBox4.Size = new Size(341, 95);
             groupBox4.TabIndex = 25;
             groupBox4.TabStop = false;
             groupBox4.Text = "Details";
@@ -388,181 +576,113 @@
             // ResultLabel
             // 
             ResultLabel.AutoSize = true;
-            ResultLabel.Location = new Point(403, 218);
+            ResultLabel.Location = new Point(31, 64);
             ResultLabel.Name = "ResultLabel";
             ResultLabel.Size = new Size(0, 15);
             ResultLabel.TabIndex = 30;
             // 
-            // FlagSearchBox
-            // 
-            FlagSearchBox.Location = new Point(403, 192);
-            FlagSearchBox.Name = "FlagSearchBox";
-            FlagSearchBox.Size = new Size(100, 23);
-            FlagSearchBox.TabIndex = 29;
-            FlagSearchBox.TextChanged += FlagSearchBox_TextChanged;
-            // 
             // FlagSearch
             // 
             FlagSearch.AutoSize = true;
-            FlagSearch.Location = new Point(421, 174);
+            FlagSearch.Location = new Point(57, 12);
             FlagSearch.Name = "FlagSearch";
             FlagSearch.Size = new Size(67, 15);
             FlagSearch.TabIndex = 28;
             FlagSearch.Text = "Flag Search";
             // 
-            // FlagUp
-            // 
-            FlagUp.Location = new Point(510, 192);
-            FlagUp.Name = "FlagUp";
-            FlagUp.Size = new Size(24, 23);
-            FlagUp.TabIndex = 31;
-            FlagUp.Text = "+";
-            FlagUp.UseVisualStyleBackColor = true;
-            FlagUp.Click += FlagUp_Click;
-            // 
-            // FlagDown
-            // 
-            FlagDown.Location = new Point(373, 192);
-            FlagDown.Name = "FlagDown";
-            FlagDown.Size = new Size(24, 23);
-            FlagDown.TabIndex = 32;
-            FlagDown.Text = "-";
-            FlagDown.UseVisualStyleBackColor = true;
-            FlagDown.Click += FlagDown_Click;
-            // 
-            // QuestDown
-            // 
-            QuestDown.Location = new Point(372, 269);
-            QuestDown.Name = "QuestDown";
-            QuestDown.Size = new Size(24, 23);
-            QuestDown.TabIndex = 44;
-            QuestDown.Text = "-";
-            QuestDown.UseVisualStyleBackColor = true;
-            QuestDown.Click += QuestDown_Click;
-            // 
-            // QuestUp
-            // 
-            QuestUp.Location = new Point(509, 269);
-            QuestUp.Name = "QuestUp";
-            QuestUp.Size = new Size(24, 23);
-            QuestUp.TabIndex = 43;
-            QuestUp.Text = "+";
-            QuestUp.UseVisualStyleBackColor = true;
-            QuestUp.Click += QuestUp_Click;
-            // 
             // QuestResultLabel
             // 
             QuestResultLabel.AutoSize = true;
-            QuestResultLabel.Location = new Point(403, 296);
+            QuestResultLabel.Location = new Point(174, 64);
             QuestResultLabel.Name = "QuestResultLabel";
             QuestResultLabel.Size = new Size(0, 15);
             QuestResultLabel.TabIndex = 42;
             // 
-            // QuestSearchBox
-            // 
-            QuestSearchBox.Location = new Point(403, 270);
-            QuestSearchBox.Name = "QuestSearchBox";
-            QuestSearchBox.Size = new Size(100, 23);
-            QuestSearchBox.TabIndex = 41;
-            QuestSearchBox.TextChanged += QuestSearchBox_TextChanged;
-            // 
             // label10
             // 
             label10.AutoSize = true;
-            label10.Location = new Point(421, 252);
+            label10.Location = new Point(196, 13);
             label10.Name = "label10";
             label10.Size = new Size(76, 15);
             label10.TabIndex = 40;
             label10.Text = "Quest Search";
             // 
-            // GameGold
+            // SearchBox
             // 
-            GameGold.AutoSize = true;
-            GameGold.Font = new Font("Segoe UI", 8F);
-            GameGold.Location = new Point(0, 201);
-            GameGold.Margin = new Padding(4, 0, 4, 0);
-            GameGold.Name = "GameGold";
-            GameGold.Size = new Size(70, 13);
-            GameGold.TabIndex = 22;
-            GameGold.Text = "GameGold : ";
+            SearchBox.Controls.Add(FlagSearchBox);
+            SearchBox.Controls.Add(QuestSearchBox);
+            SearchBox.Controls.Add(FlagSearch);
+            SearchBox.Controls.Add(ResultLabel);
+            SearchBox.Controls.Add(QuestResultLabel);
+            SearchBox.Controls.Add(label10);
+            SearchBox.Location = new Point(356, 177);
+            SearchBox.Name = "SearchBox";
+            SearchBox.Size = new Size(324, 102);
+            SearchBox.TabIndex = 45;
+            SearchBox.TabStop = false;
+            SearchBox.Text = "Search";
             // 
-            // GameGoldTextBox
+            // FlagSearchBox
             // 
-            GameGoldTextBox.Location = new Point(70, 198);
-            GameGoldTextBox.Margin = new Padding(4, 3, 4, 3);
-            GameGoldTextBox.Name = "GameGoldTextBox";
-            GameGoldTextBox.Size = new Size(116, 23);
-            GameGoldTextBox.TabIndex = 23;
+            FlagSearchBox.Location = new Point(31, 35);
+            FlagSearchBox.Name = "FlagSearchBox";
+            FlagSearchBox.Size = new Size(120, 23);
+            FlagSearchBox.TabIndex = 46;
+            FlagSearchBox.ValueChanged += FlagSearchBox_ValueChanged;
             // 
-            // Gold
+            // QuestSearchBox
             // 
-            Gold.AutoSize = true;
-            Gold.Location = new Point(10, 172);
-            Gold.Margin = new Padding(4, 0, 4, 0);
-            Gold.Name = "Gold";
-            Gold.Size = new Size(41, 15);
-            Gold.TabIndex = 20;
-            Gold.Text = "Gold : ";
+            QuestSearchBox.Location = new Point(174, 35);
+            QuestSearchBox.Name = "QuestSearchBox";
+            QuestSearchBox.Size = new Size(120, 23);
+            QuestSearchBox.TabIndex = 47;
+            QuestSearchBox.ValueChanged += QuestSearchBox_ValueChanged;
             // 
-            // GoldTextBox
+            // PetView
             // 
-            GoldTextBox.Location = new Point(70, 169);
-            GoldTextBox.Margin = new Padding(4, 3, 4, 3);
-            GoldTextBox.Name = "GoldTextBox";
-            GoldTextBox.Size = new Size(116, 23);
-            GoldTextBox.TabIndex = 21;
+            PetView.Columns.AddRange(new ColumnHeader[] { Pet, Level, HP, Location });
+            PetView.Location = new Point(6, 14);
+            PetView.Name = "PetView";
+            PetView.Size = new Size(459, 144);
+            PetView.TabIndex = 0;
+            PetView.UseCompatibleStateImageBehavior = false;
+            PetView.View = View.Details;
             // 
-            // PKPoints
+            // Pet
             // 
-            PKPoints.AutoSize = true;
-            PKPoints.Location = new Point(10, 143);
-            PKPoints.Margin = new Padding(4, 0, 4, 0);
-            PKPoints.Name = "PKPoints";
-            PKPoints.Size = new Size(58, 15);
-            PKPoints.TabIndex = 18;
-            PKPoints.Text = "PKPoint : ";
+            Pet.Text = "Pet";
+            Pet.Width = 150;
             // 
-            // PKPointsTextBox
+            // Level
             // 
-            PKPointsTextBox.Location = new Point(70, 140);
-            PKPointsTextBox.Margin = new Padding(4, 3, 4, 3);
-            PKPointsTextBox.Name = "PKPointsTextBox";
-            PKPointsTextBox.Size = new Size(116, 23);
-            PKPointsTextBox.TabIndex = 19;
+            Level.Text = "Level";
             // 
-            // label12
+            // HP
             // 
-            label12.AutoSize = true;
-            label12.Location = new Point(10, 114);
-            label12.Margin = new Padding(4, 0, 4, 0);
-            label12.Name = "label12";
-            label12.Size = new Size(36, 15);
-            label12.TabIndex = 16;
-            label12.Text = "EXP : ";
+            HP.Text = "HP";
             // 
-            // ExpTextBox
+            // Location
             // 
-            ExpTextBox.Location = new Point(70, 111);
-            ExpTextBox.Margin = new Padding(4, 3, 4, 3);
-            ExpTextBox.Name = "ExpTextBox";
-            ExpTextBox.Size = new Size(116, 23);
-            ExpTextBox.TabIndex = 17;
+            Location.Text = "Location";
+            Location.Width = 250;
+            // 
+            // Pets
+            // 
+            Pets.Controls.Add(PetView);
+            Pets.Location = new Point(356, 285);
+            Pets.Name = "Pets";
+            Pets.Size = new Size(471, 171);
+            Pets.TabIndex = 46;
+            Pets.TabStop = false;
+            Pets.Text = "Pets";
             // 
             // PlayerInfoForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(544, 424);
-            Controls.Add(QuestDown);
-            Controls.Add(QuestUp);
-            Controls.Add(QuestResultLabel);
-            Controls.Add(QuestSearchBox);
-            Controls.Add(label10);
-            Controls.Add(FlagDown);
-            Controls.Add(FlagUp);
-            Controls.Add(ResultLabel);
-            Controls.Add(FlagSearchBox);
-            Controls.Add(FlagSearch);
+            ClientSize = new Size(827, 446);
+            Controls.Add(Pets);
+            Controls.Add(SearchBox);
             Controls.Add(groupBox4);
             Controls.Add(groupBox3);
             Controls.Add(groupBox2);
@@ -578,8 +698,12 @@
             groupBox3.PerformLayout();
             groupBox4.ResumeLayout(false);
             groupBox4.PerformLayout();
+            SearchBox.ResumeLayout(false);
+            SearchBox.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)FlagSearchBox).EndInit();
+            ((System.ComponentModel.ISupportInitialize)QuestSearchBox).EndInit();
+            Pets.ResumeLayout(false);
             ResumeLayout(false);
-            PerformLayout();
         }
 
         #endregion
@@ -612,14 +736,8 @@
         private System.Windows.Forms.Button SafeZoneButton;
         private System.Windows.Forms.Button OpenAccountButton;
         private Label ResultLabel;
-        private TextBox FlagSearchBox;
         private Label FlagSearch;
-        private Button FlagUp;
-        private Button FlagDown;
-        private Button QuestDown;
-        private Button QuestUp;
         private Label QuestResultLabel;
-        private TextBox QuestSearchBox;
         private Label label10;
         private Label GameGold;
         private TextBox GameGoldTextBox;
@@ -629,5 +747,23 @@
         private TextBox PKPointsTextBox;
         private Label label12;
         private TextBox ExpTextBox;
+        private TextBox ATKSPDBox;
+        private TextBox AGILBox;
+        private TextBox ACCBox;
+        private TextBox SCBox;
+        private TextBox MCBox;
+        private TextBox DCBox;
+        private TextBox AMCBox;
+        private TextBox ACBox;
+        private Label StatsLabel;
+        private GroupBox SearchBox;
+        private NumericUpDown QuestSearchBox;
+        private NumericUpDown FlagSearchBox;
+        private ListView PetView;
+        private ColumnHeader Pet;
+        private ColumnHeader Level;
+        private ColumnHeader HP;
+        private ColumnHeader Location;
+        private GroupBox Pets;
     }
 }

--- a/Server.MirForms/Account/PlayerInfoForm.Designer.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.Designer.cs
@@ -386,6 +386,7 @@
             ExpTextBox.Location = new Point(70, 111);
             ExpTextBox.Margin = new Padding(4, 3, 4, 3);
             ExpTextBox.Name = "ExpTextBox";
+            ExpTextBox.ReadOnly = true;
             ExpTextBox.Size = new Size(116, 23);
             ExpTextBox.TabIndex = 17;
             // 

--- a/Server.MirForms/Account/PlayerInfoForm.Designer.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.Designer.cs
@@ -73,27 +73,47 @@
             label8 = new Label();
             CurrentIPLabel = new Label();
             groupBox4 = new GroupBox();
-            ResultLabel = new Label();
-            FlagSearch = new Label();
-            QuestResultLabel = new Label();
-            label10 = new Label();
+            tabControl1 = new TabControl();
+            PlayerInfoTab = new TabPage();
             SearchBox = new GroupBox();
             FlagSearchBox = new NumericUpDown();
-            QuestSearchBox = new NumericUpDown();
+            FlagSearch = new Label();
+            ResultLabel = new Label();
+            QuestInfoTab = new TabPage();
+            QuestInfoListViewNF = new CustomFormControl.ListViewNF();
+            QuestIndexHeader = new ColumnHeader();
+            QuestStatusHeader = new ColumnHeader();
+            ItemInfoTab = new TabPage();
+            PlayerItemInfoListViewNF = new CustomFormControl.ListViewNF();
+            UIDHeader = new ColumnHeader();
+            LocationHeader = new ColumnHeader();
+            NameHeader = new ColumnHeader();
+            CountHeader = new ColumnHeader();
+            DurabilityHeader = new ColumnHeader();
+            MagicInfoTab = new TabPage();
+            MagicListViewNF = new CustomFormControl.ListViewNF();
+            MagicNameHeader = new ColumnHeader();
+            MagicLevelHeader = new ColumnHeader();
+            MagicExperienceHeader = new ColumnHeader();
+            Key = new ColumnHeader();
+            PetInfoTab = new TabPage();
             PetView = new ListView();
-            Pet = new ColumnHeader();
+            PetName = new ColumnHeader();
             Level = new ColumnHeader();
             HP = new ColumnHeader();
             Location = new ColumnHeader();
-            Pets = new GroupBox();
             groupBox1.SuspendLayout();
             groupBox2.SuspendLayout();
             groupBox3.SuspendLayout();
             groupBox4.SuspendLayout();
+            tabControl1.SuspendLayout();
+            PlayerInfoTab.SuspendLayout();
             SearchBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)FlagSearchBox).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)QuestSearchBox).BeginInit();
-            Pets.SuspendLayout();
+            QuestInfoTab.SuspendLayout();
+            ItemInfoTab.SuspendLayout();
+            MagicInfoTab.SuspendLayout();
+            PetInfoTab.SuspendLayout();
             SuspendLayout();
             // 
             // label1
@@ -218,7 +238,7 @@
             groupBox1.Controls.Add(IndexTextBox);
             groupBox1.Controls.Add(UpdateButton);
             groupBox1.Controls.Add(LevelTextBox);
-            groupBox1.Location = new Point(7, 14);
+            groupBox1.Location = new Point(4, 3);
             groupBox1.Margin = new Padding(4, 3, 4, 3);
             groupBox1.Name = "groupBox1";
             groupBox1.Padding = new Padding(4, 3, 4, 3);
@@ -402,7 +422,7 @@
             groupBox2.Controls.Add(KillPetsButton);
             groupBox2.Controls.Add(KillButton);
             groupBox2.Controls.Add(KickButton);
-            groupBox2.Location = new Point(356, 14);
+            groupBox2.Location = new Point(353, 3);
             groupBox2.Margin = new Padding(4, 3, 4, 3);
             groupBox2.Name = "groupBox2";
             groupBox2.Padding = new Padding(4, 3, 4, 3);
@@ -500,7 +520,7 @@
             // 
             groupBox3.Controls.Add(SendMessageTextBox);
             groupBox3.Controls.Add(SendMessageButton);
-            groupBox3.Location = new Point(8, 386);
+            groupBox3.Location = new Point(5, 375);
             groupBox3.Margin = new Padding(4, 3, 4, 3);
             groupBox3.Name = "groupBox3";
             groupBox3.Padding = new Padding(4, 3, 4, 3);
@@ -578,7 +598,7 @@
             groupBox4.Controls.Add(label5);
             groupBox4.Controls.Add(OnlineTimeLabel);
             groupBox4.Controls.Add(label6);
-            groupBox4.Location = new Point(7, 285);
+            groupBox4.Location = new Point(4, 274);
             groupBox4.Margin = new Padding(4, 3, 4, 3);
             groupBox4.Name = "groupBox4";
             groupBox4.Padding = new Padding(4, 3, 4, 3);
@@ -587,13 +607,54 @@
             groupBox4.TabStop = false;
             groupBox4.Text = "Details";
             // 
-            // ResultLabel
+            // tabControl1
             // 
-            ResultLabel.AutoSize = true;
-            ResultLabel.Location = new Point(31, 64);
-            ResultLabel.Name = "ResultLabel";
-            ResultLabel.Size = new Size(0, 15);
-            ResultLabel.TabIndex = 30;
+            tabControl1.Controls.Add(PlayerInfoTab);
+            tabControl1.Controls.Add(QuestInfoTab);
+            tabControl1.Controls.Add(ItemInfoTab);
+            tabControl1.Controls.Add(MagicInfoTab);
+            tabControl1.Controls.Add(PetInfoTab);
+            tabControl1.Location = new Point(-1, 2);
+            tabControl1.Name = "tabControl1";
+            tabControl1.SelectedIndex = 0;
+            tabControl1.Size = new Size(693, 465);
+            tabControl1.TabIndex = 47;
+            tabControl1.SelectedIndexChanged += tabControl1_SelectedIndexChanged;
+            // 
+            // PlayerInfoTab
+            // 
+            PlayerInfoTab.Controls.Add(SearchBox);
+            PlayerInfoTab.Controls.Add(groupBox1);
+            PlayerInfoTab.Controls.Add(groupBox2);
+            PlayerInfoTab.Controls.Add(groupBox3);
+            PlayerInfoTab.Controls.Add(groupBox4);
+            PlayerInfoTab.Location = new Point(4, 24);
+            PlayerInfoTab.Name = "PlayerInfoTab";
+            PlayerInfoTab.Padding = new Padding(3);
+            PlayerInfoTab.Size = new Size(685, 437);
+            PlayerInfoTab.TabIndex = 0;
+            PlayerInfoTab.Text = "Player Info";
+            PlayerInfoTab.UseVisualStyleBackColor = true;
+            // 
+            // SearchBox
+            // 
+            SearchBox.Controls.Add(FlagSearchBox);
+            SearchBox.Controls.Add(FlagSearch);
+            SearchBox.Controls.Add(ResultLabel);
+            SearchBox.Location = new Point(354, 171);
+            SearchBox.Name = "SearchBox";
+            SearchBox.Size = new Size(189, 97);
+            SearchBox.TabIndex = 48;
+            SearchBox.TabStop = false;
+            SearchBox.Text = "Search";
+            // 
+            // FlagSearchBox
+            // 
+            FlagSearchBox.Location = new Point(31, 35);
+            FlagSearchBox.Name = "FlagSearchBox";
+            FlagSearchBox.Size = new Size(120, 23);
+            FlagSearchBox.TabIndex = 46;
+            FlagSearchBox.ValueChanged += FlagSearchBox_ValueChanged_1;
             // 
             // FlagSearch
             // 
@@ -604,68 +665,162 @@
             FlagSearch.TabIndex = 28;
             FlagSearch.Text = "Flag Search";
             // 
-            // QuestResultLabel
+            // ResultLabel
             // 
-            QuestResultLabel.AutoSize = true;
-            QuestResultLabel.Location = new Point(174, 64);
-            QuestResultLabel.Name = "QuestResultLabel";
-            QuestResultLabel.Size = new Size(0, 15);
-            QuestResultLabel.TabIndex = 42;
+            ResultLabel.AutoSize = true;
+            ResultLabel.Location = new Point(31, 64);
+            ResultLabel.Name = "ResultLabel";
+            ResultLabel.Size = new Size(0, 15);
+            ResultLabel.TabIndex = 30;
             // 
-            // label10
+            // QuestInfoTab
             // 
-            label10.AutoSize = true;
-            label10.Location = new Point(196, 13);
-            label10.Name = "label10";
-            label10.Size = new Size(76, 15);
-            label10.TabIndex = 40;
-            label10.Text = "Quest Search";
+            QuestInfoTab.Controls.Add(QuestInfoListViewNF);
+            QuestInfoTab.Location = new Point(4, 24);
+            QuestInfoTab.Name = "QuestInfoTab";
+            QuestInfoTab.Padding = new Padding(3);
+            QuestInfoTab.Size = new Size(685, 437);
+            QuestInfoTab.TabIndex = 1;
+            QuestInfoTab.Text = "Quest Info";
+            QuestInfoTab.UseVisualStyleBackColor = true;
             // 
-            // SearchBox
+            // QuestInfoListViewNF
             // 
-            SearchBox.Controls.Add(FlagSearchBox);
-            SearchBox.Controls.Add(QuestSearchBox);
-            SearchBox.Controls.Add(FlagSearch);
-            SearchBox.Controls.Add(ResultLabel);
-            SearchBox.Controls.Add(QuestResultLabel);
-            SearchBox.Controls.Add(label10);
-            SearchBox.Location = new Point(356, 177);
-            SearchBox.Name = "SearchBox";
-            SearchBox.Size = new Size(324, 102);
-            SearchBox.TabIndex = 45;
-            SearchBox.TabStop = false;
-            SearchBox.Text = "Search";
+            QuestInfoListViewNF.Columns.AddRange(new ColumnHeader[] { QuestIndexHeader, QuestStatusHeader });
+            QuestInfoListViewNF.Dock = DockStyle.Fill;
+            QuestInfoListViewNF.GridLines = true;
+            QuestInfoListViewNF.Location = new Point(3, 3);
+            QuestInfoListViewNF.Name = "QuestInfoListViewNF";
+            QuestInfoListViewNF.Size = new Size(679, 431);
+            QuestInfoListViewNF.TabIndex = 1;
+            QuestInfoListViewNF.UseCompatibleStateImageBehavior = false;
+            QuestInfoListViewNF.View = View.Details;
             // 
-            // FlagSearchBox
+            // QuestIndexHeader
             // 
-            FlagSearchBox.Location = new Point(31, 35);
-            FlagSearchBox.Name = "FlagSearchBox";
-            FlagSearchBox.Size = new Size(120, 23);
-            FlagSearchBox.TabIndex = 46;
-            FlagSearchBox.ValueChanged += FlagSearchBox_ValueChanged;
+            QuestIndexHeader.Text = "Index";
+            QuestIndexHeader.Width = 100;
             // 
-            // QuestSearchBox
+            // QuestStatusHeader
             // 
-            QuestSearchBox.Location = new Point(174, 35);
-            QuestSearchBox.Name = "QuestSearchBox";
-            QuestSearchBox.Size = new Size(120, 23);
-            QuestSearchBox.TabIndex = 47;
-            QuestSearchBox.ValueChanged += QuestSearchBox_ValueChanged;
+            QuestStatusHeader.Text = "Status";
+            QuestStatusHeader.Width = 100;
+            // 
+            // ItemInfoTab
+            // 
+            ItemInfoTab.Controls.Add(PlayerItemInfoListViewNF);
+            ItemInfoTab.Location = new Point(4, 24);
+            ItemInfoTab.Name = "ItemInfoTab";
+            ItemInfoTab.Size = new Size(685, 437);
+            ItemInfoTab.TabIndex = 2;
+            ItemInfoTab.Text = "Item Info";
+            ItemInfoTab.UseVisualStyleBackColor = true;
+            // 
+            // PlayerItemInfoListViewNF
+            // 
+            PlayerItemInfoListViewNF.Columns.AddRange(new ColumnHeader[] { UIDHeader, LocationHeader, NameHeader, CountHeader, DurabilityHeader });
+            PlayerItemInfoListViewNF.Dock = DockStyle.Fill;
+            PlayerItemInfoListViewNF.GridLines = true;
+            PlayerItemInfoListViewNF.Location = new Point(0, 0);
+            PlayerItemInfoListViewNF.Name = "PlayerItemInfoListViewNF";
+            PlayerItemInfoListViewNF.Size = new Size(685, 437);
+            PlayerItemInfoListViewNF.TabIndex = 2;
+            PlayerItemInfoListViewNF.UseCompatibleStateImageBehavior = false;
+            PlayerItemInfoListViewNF.View = View.Details;
+            // 
+            // UIDHeader
+            // 
+            UIDHeader.Text = "UID";
+            UIDHeader.Width = 100;
+            // 
+            // LocationHeader
+            // 
+            LocationHeader.Text = "Location";
+            LocationHeader.Width = 150;
+            // 
+            // NameHeader
+            // 
+            NameHeader.Text = "Name";
+            NameHeader.Width = 150;
+            // 
+            // CountHeader
+            // 
+            CountHeader.Text = "Count";
+            CountHeader.Width = 80;
+            // 
+            // DurabilityHeader
+            // 
+            DurabilityHeader.Text = "Durability";
+            DurabilityHeader.Width = 90;
+            // 
+            // MagicInfoTab
+            // 
+            MagicInfoTab.Controls.Add(MagicListViewNF);
+            MagicInfoTab.Location = new Point(4, 24);
+            MagicInfoTab.Name = "MagicInfoTab";
+            MagicInfoTab.Size = new Size(685, 437);
+            MagicInfoTab.TabIndex = 3;
+            MagicInfoTab.Text = "Magic Info";
+            MagicInfoTab.UseVisualStyleBackColor = true;
+            // 
+            // MagicListViewNF
+            // 
+            MagicListViewNF.Columns.AddRange(new ColumnHeader[] { MagicNameHeader, MagicLevelHeader, MagicExperienceHeader, Key });
+            MagicListViewNF.Dock = DockStyle.Fill;
+            MagicListViewNF.GridLines = true;
+            MagicListViewNF.Location = new Point(0, 0);
+            MagicListViewNF.Name = "MagicListViewNF";
+            MagicListViewNF.Size = new Size(685, 437);
+            MagicListViewNF.TabIndex = 2;
+            MagicListViewNF.UseCompatibleStateImageBehavior = false;
+            MagicListViewNF.View = View.Details;
+            // 
+            // MagicNameHeader
+            // 
+            MagicNameHeader.Text = "Spell Name";
+            MagicNameHeader.Width = 150;
+            // 
+            // MagicLevelHeader
+            // 
+            MagicLevelHeader.Text = "Level";
+            MagicLevelHeader.Width = 50;
+            // 
+            // MagicExperienceHeader
+            // 
+            MagicExperienceHeader.Text = "Experience";
+            MagicExperienceHeader.Width = 150;
+            // 
+            // Key
+            // 
+            Key.Text = "Key";
+            Key.Width = 80;
+            // 
+            // PetInfoTab
+            // 
+            PetInfoTab.Controls.Add(PetView);
+            PetInfoTab.Location = new Point(4, 24);
+            PetInfoTab.Name = "PetInfoTab";
+            PetInfoTab.Size = new Size(685, 437);
+            PetInfoTab.TabIndex = 4;
+            PetInfoTab.Text = "Pet Info";
+            PetInfoTab.UseVisualStyleBackColor = true;
             // 
             // PetView
             // 
-            PetView.Columns.AddRange(new ColumnHeader[] { Pet, Level, HP, Location });
-            PetView.Location = new Point(6, 14);
+            PetView.Columns.AddRange(new ColumnHeader[] { PetName, Level, HP, Location });
+            PetView.Dock = DockStyle.Fill;
+            PetView.GridLines = true;
+            PetView.Location = new Point(0, 0);
             PetView.Name = "PetView";
-            PetView.Size = new Size(459, 144);
-            PetView.TabIndex = 0;
+            PetView.Size = new Size(685, 437);
+            PetView.TabIndex = 1;
             PetView.UseCompatibleStateImageBehavior = false;
             PetView.View = View.Details;
             // 
-            // Pet
+            // PetName
             // 
-            Pet.Text = "Pet";
-            Pet.Width = 150;
+            PetName.Text = "Name";
+            PetName.Width = 150;
             // 
             // Level
             // 
@@ -678,29 +833,14 @@
             // Location
             // 
             Location.Text = "Location";
-            Location.Width = 250;
-            // 
-            // Pets
-            // 
-            Pets.Controls.Add(PetView);
-            Pets.Location = new Point(356, 285);
-            Pets.Name = "Pets";
-            Pets.Size = new Size(471, 171);
-            Pets.TabIndex = 46;
-            Pets.TabStop = false;
-            Pets.Text = "Pets";
+            Location.Width = 240;
             // 
             // PlayerInfoForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(827, 446);
-            Controls.Add(Pets);
-            Controls.Add(SearchBox);
-            Controls.Add(groupBox4);
-            Controls.Add(groupBox3);
-            Controls.Add(groupBox2);
-            Controls.Add(groupBox1);
+            ClientSize = new Size(692, 471);
+            Controls.Add(tabControl1);
             Margin = new Padding(4, 3, 4, 3);
             Name = "PlayerInfoForm";
             Text = "PlayerInfoForm";
@@ -712,11 +852,15 @@
             groupBox3.PerformLayout();
             groupBox4.ResumeLayout(false);
             groupBox4.PerformLayout();
+            tabControl1.ResumeLayout(false);
+            PlayerInfoTab.ResumeLayout(false);
             SearchBox.ResumeLayout(false);
             SearchBox.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)FlagSearchBox).EndInit();
-            ((System.ComponentModel.ISupportInitialize)QuestSearchBox).EndInit();
-            Pets.ResumeLayout(false);
+            QuestInfoTab.ResumeLayout(false);
+            ItemInfoTab.ResumeLayout(false);
+            MagicInfoTab.ResumeLayout(false);
+            PetInfoTab.ResumeLayout(false);
             ResumeLayout(false);
         }
 
@@ -749,10 +893,6 @@
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.Button SafeZoneButton;
         private System.Windows.Forms.Button OpenAccountButton;
-        private Label ResultLabel;
-        private Label FlagSearch;
-        private Label QuestResultLabel;
-        private Label label10;
         private Label GameGold;
         private TextBox GameGoldTextBox;
         private Label Gold;
@@ -770,15 +910,35 @@
         private TextBox AMCBox;
         private TextBox ACBox;
         private Label StatsLabel;
+        private Button AccountBanButton;
+        private TabControl tabControl1;
+        private TabPage PlayerInfoTab;
+        private TabPage QuestInfoTab;
+        private TabPage ItemInfoTab;
+        private TabPage MagicInfoTab;
+        private TabPage PetInfoTab;
         private GroupBox SearchBox;
-        private NumericUpDown QuestSearchBox;
         private NumericUpDown FlagSearchBox;
+        private Label FlagSearch;
+        private Label ResultLabel;
+        private CustomFormControl.ListViewNF QuestInfoListViewNF;
+        private ColumnHeader QuestIndexHeader;
+        private ColumnHeader QuestStatusHeader;
+        private CustomFormControl.ListViewNF MagicListViewNF;
+        private ColumnHeader MagicNameHeader;
+        private ColumnHeader MagicLevelHeader;
+        private ColumnHeader MagicExperienceHeader;
+        private ColumnHeader Key;
         private ListView PetView;
-        private ColumnHeader Pet;
+        private ColumnHeader PetName;
         private ColumnHeader Level;
         private ColumnHeader HP;
         private ColumnHeader Location;
-        private GroupBox Pets;
-        private Button AccountBanButton;
+        private CustomFormControl.ListViewNF PlayerItemInfoListViewNF;
+        private ColumnHeader UIDHeader;
+        private ColumnHeader LocationHeader;
+        private ColumnHeader NameHeader;
+        private ColumnHeader CountHeader;
+        private ColumnHeader DurabilityHeader;
     }
 }

--- a/Server.MirForms/Account/PlayerInfoForm.Designer.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.Designer.cs
@@ -57,6 +57,7 @@
             label12 = new Label();
             ExpTextBox = new TextBox();
             groupBox2 = new GroupBox();
+            AccountBanButton = new Button();
             OpenAccountButton = new Button();
             SafeZoneButton = new Button();
             label9 = new Label();
@@ -85,7 +86,6 @@
             HP = new ColumnHeader();
             Location = new ColumnHeader();
             Pets = new GroupBox();
-            AccountBanButton = new Button();
             groupBox1.SuspendLayout();
             groupBox2.SuspendLayout();
             groupBox3.SuspendLayout();
@@ -158,7 +158,7 @@
             UpdateButton.Name = "UpdateButton";
             UpdateButton.Size = new Size(88, 27);
             UpdateButton.TabIndex = 7;
-            UpdateButton.Text = "Update Details";
+            UpdateButton.Text = "Update";
             UpdateButton.UseVisualStyleBackColor = true;
             UpdateButton.Click += UpdateButton_Click;
             // 
@@ -183,7 +183,7 @@
             // 
             // SendMessageButton
             // 
-            SendMessageButton.Location = new Point(266, 22);
+            SendMessageButton.Location = new Point(265, 22);
             SendMessageButton.Margin = new Padding(4, 3, 4, 3);
             SendMessageButton.Name = "SendMessageButton";
             SendMessageButton.Size = new Size(68, 27);
@@ -313,9 +313,9 @@
             StatsLabel.Location = new Point(197, 23);
             StatsLabel.Margin = new Padding(4, 0, 4, 0);
             StatsLabel.Name = "StatsLabel";
-            StatsLabel.Size = new Size(54, 225);
+            StatsLabel.Size = new Size(57, 225);
             StatsLabel.TabIndex = 25;
-            StatsLabel.Text = "AC:\r\n\r\nAMC:\r\n\r\nDC:\r\n\r\nMC:\r\n\r\nSC:\r\n\r\nACC:\r\n\r\nAGIL:\r\n\r\nATK SPD:";
+            StatsLabel.Text = "AC :\r\n\r\nAMC :\r\n\r\nDC :\r\n\r\nMC :\r\n\r\nSC :\r\n\r\nACC :\r\n\r\nAGIL :\r\n\r\nATK SPD :";
             // 
             // GameGold
             // 
@@ -410,6 +410,17 @@
             groupBox2.TabIndex = 12;
             groupBox2.TabStop = false;
             groupBox2.Text = "Actions";
+            // 
+            // AccountBanButton
+            // 
+            AccountBanButton.Location = new Point(7, 88);
+            AccountBanButton.Margin = new Padding(4, 3, 4, 3);
+            AccountBanButton.Name = "AccountBanButton";
+            AccountBanButton.Size = new Size(88, 27);
+            AccountBanButton.TabIndex = 25;
+            AccountBanButton.Text = "Account Ban";
+            AccountBanButton.UseVisualStyleBackColor = true;
+            AccountBanButton.Click += AccountBanButton_Click;
             // 
             // OpenAccountButton
             // 
@@ -678,17 +689,6 @@
             Pets.TabIndex = 46;
             Pets.TabStop = false;
             Pets.Text = "Pets";
-            // 
-            // AccountBanButton
-            // 
-            AccountBanButton.Location = new Point(7, 88);
-            AccountBanButton.Margin = new Padding(4, 3, 4, 3);
-            AccountBanButton.Name = "AccountBanButton";
-            AccountBanButton.Size = new Size(88, 27);
-            AccountBanButton.TabIndex = 25;
-            AccountBanButton.Text = "Acount Ban";
-            AccountBanButton.UseVisualStyleBackColor = true;
-            AccountBanButton.Click += AccountBanButton_Click;
             // 
             // PlayerInfoForm
             // 

--- a/Server.MirForms/Account/PlayerInfoForm.Designer.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.Designer.cs
@@ -85,6 +85,7 @@
             HP = new ColumnHeader();
             Location = new ColumnHeader();
             Pets = new GroupBox();
+            AccountBanButton = new Button();
             groupBox1.SuspendLayout();
             groupBox2.SuspendLayout();
             groupBox3.SuspendLayout();
@@ -392,6 +393,7 @@
             // 
             // groupBox2
             // 
+            groupBox2.Controls.Add(AccountBanButton);
             groupBox2.Controls.Add(OpenAccountButton);
             groupBox2.Controls.Add(SafeZoneButton);
             groupBox2.Controls.Add(label9);
@@ -434,7 +436,7 @@
             // label9
             // 
             label9.AutoSize = true;
-            label9.Location = new Point(108, 127);
+            label9.Location = new Point(108, 110);
             label9.Margin = new Padding(4, 0, 4, 0);
             label9.Name = "label9";
             label9.Size = new Size(53, 15);
@@ -443,7 +445,7 @@
             // 
             // ChatBanExpiryTextBox
             // 
-            ChatBanExpiryTextBox.Location = new Point(174, 123);
+            ChatBanExpiryTextBox.Location = new Point(174, 106);
             ChatBanExpiryTextBox.Margin = new Padding(4, 3, 4, 3);
             ChatBanExpiryTextBox.Name = "ChatBanExpiryTextBox";
             ChatBanExpiryTextBox.Size = new Size(137, 23);
@@ -463,7 +465,7 @@
             // 
             // KillPetsButton
             // 
-            KillPetsButton.Location = new Point(7, 89);
+            KillPetsButton.Location = new Point(103, 55);
             KillPetsButton.Margin = new Padding(4, 3, 4, 3);
             KillPetsButton.Name = "KillPetsButton";
             KillPetsButton.Size = new Size(88, 27);
@@ -677,6 +679,17 @@
             Pets.TabStop = false;
             Pets.Text = "Pets";
             // 
+            // AccountBanButton
+            // 
+            AccountBanButton.Location = new Point(7, 88);
+            AccountBanButton.Margin = new Padding(4, 3, 4, 3);
+            AccountBanButton.Name = "AccountBanButton";
+            AccountBanButton.Size = new Size(88, 27);
+            AccountBanButton.TabIndex = 25;
+            AccountBanButton.Text = "Acount Ban";
+            AccountBanButton.UseVisualStyleBackColor = true;
+            AccountBanButton.Click += AccountBanButton_Click;
+            // 
             // PlayerInfoForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
@@ -766,5 +779,6 @@
         private ColumnHeader HP;
         private ColumnHeader Location;
         private GroupBox Pets;
+        private Button AccountBanButton;
     }
 }

--- a/Server.MirForms/Account/PlayerInfoForm.Designer.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.Designer.cs
@@ -50,12 +50,8 @@
             groupBox3 = new GroupBox();
             CurrentMapLabel = new Label();
             label5 = new Label();
-            label4 = new Label();
-            PKPointsLabel = new Label();
             label6 = new Label();
             OnlineTimeLabel = new Label();
-            label7 = new Label();
-            GoldLabel = new Label();
             label8 = new Label();
             CurrentIPLabel = new Label();
             groupBox4 = new GroupBox();
@@ -69,6 +65,14 @@
             QuestResultLabel = new Label();
             QuestSearchBox = new TextBox();
             label10 = new Label();
+            GameGold = new Label();
+            GameGoldTextBox = new TextBox();
+            Gold = new Label();
+            GoldTextBox = new TextBox();
+            PKPoints = new Label();
+            PKPointsTextBox = new TextBox();
+            label12 = new Label();
+            ExpTextBox = new TextBox();
             groupBox1.SuspendLayout();
             groupBox2.SuspendLayout();
             groupBox3.SuspendLayout();
@@ -132,7 +136,7 @@
             // 
             // UpdateButton
             // 
-            UpdateButton.Location = new Point(102, 112);
+            UpdateButton.Location = new Point(108, 238);
             UpdateButton.Margin = new Padding(4, 3, 4, 3);
             UpdateButton.Name = "UpdateButton";
             UpdateButton.Size = new Size(88, 27);
@@ -173,6 +177,14 @@
             // 
             // groupBox1
             // 
+            groupBox1.Controls.Add(GameGold);
+            groupBox1.Controls.Add(GameGoldTextBox);
+            groupBox1.Controls.Add(Gold);
+            groupBox1.Controls.Add(GoldTextBox);
+            groupBox1.Controls.Add(PKPoints);
+            groupBox1.Controls.Add(PKPointsTextBox);
+            groupBox1.Controls.Add(label12);
+            groupBox1.Controls.Add(ExpTextBox);
             groupBox1.Controls.Add(label2);
             groupBox1.Controls.Add(label1);
             groupBox1.Controls.Add(label3);
@@ -184,7 +196,7 @@
             groupBox1.Margin = new Padding(4, 3, 4, 3);
             groupBox1.Name = "groupBox1";
             groupBox1.Padding = new Padding(4, 3, 4, 3);
-            groupBox1.Size = new Size(196, 157);
+            groupBox1.Size = new Size(196, 265);
             groupBox1.TabIndex = 11;
             groupBox1.TabStop = false;
             groupBox1.Text = "Character Info";
@@ -286,7 +298,7 @@
             // 
             groupBox3.Controls.Add(SendMessageTextBox);
             groupBox3.Controls.Add(SendMessageButton);
-            groupBox3.Location = new Point(7, 315);
+            groupBox3.Location = new Point(7, 365);
             groupBox3.Margin = new Padding(4, 3, 4, 3);
             groupBox3.Name = "groupBox3";
             groupBox3.Padding = new Padding(4, 3, 4, 3);
@@ -298,7 +310,7 @@
             // CurrentMapLabel
             // 
             CurrentMapLabel.AutoSize = true;
-            CurrentMapLabel.Location = new Point(132, 36);
+            CurrentMapLabel.Location = new Point(128, 19);
             CurrentMapLabel.Margin = new Padding(4, 0, 4, 0);
             CurrentMapLabel.Name = "CurrentMapLabel";
             CurrentMapLabel.Size = new Size(37, 15);
@@ -308,37 +320,17 @@
             // label5
             // 
             label5.AutoSize = true;
-            label5.Location = new Point(12, 36);
+            label5.Location = new Point(8, 19);
             label5.Margin = new Padding(4, 0, 4, 0);
             label5.Name = "label5";
             label5.Size = new Size(105, 15);
             label5.TabIndex = 16;
             label5.Text = "Current Location : ";
             // 
-            // label4
-            // 
-            label4.AutoSize = true;
-            label4.Location = new Point(12, 55);
-            label4.Margin = new Padding(4, 0, 4, 0);
-            label4.Name = "label4";
-            label4.Size = new Size(66, 15);
-            label4.TabIndex = 17;
-            label4.Text = "PK Points : ";
-            // 
-            // PKPointsLabel
-            // 
-            PKPointsLabel.AutoSize = true;
-            PKPointsLabel.Location = new Point(132, 55);
-            PKPointsLabel.Margin = new Padding(4, 0, 4, 0);
-            PKPointsLabel.Name = "PKPointsLabel";
-            PKPointsLabel.Size = new Size(54, 15);
-            PKPointsLabel.TabIndex = 18;
-            PKPointsLabel.Text = "$pkpoint";
-            // 
             // label6
             // 
             label6.AutoSize = true;
-            label6.Location = new Point(12, 75);
+            label6.Location = new Point(8, 37);
             label6.Margin = new Padding(4, 0, 4, 0);
             label6.Name = "label6";
             label6.Size = new Size(80, 15);
@@ -348,37 +340,17 @@
             // OnlineTimeLabel
             // 
             OnlineTimeLabel.AutoSize = true;
-            OnlineTimeLabel.Location = new Point(132, 75);
+            OnlineTimeLabel.Location = new Point(128, 37);
             OnlineTimeLabel.Margin = new Padding(4, 0, 4, 0);
             OnlineTimeLabel.Name = "OnlineTimeLabel";
             OnlineTimeLabel.Size = new Size(70, 15);
             OnlineTimeLabel.TabIndex = 20;
             OnlineTimeLabel.Text = "$onlinetime";
             // 
-            // label7
-            // 
-            label7.AutoSize = true;
-            label7.Location = new Point(12, 18);
-            label7.Margin = new Padding(4, 0, 4, 0);
-            label7.Name = "label7";
-            label7.Size = new Size(69, 15);
-            label7.TabIndex = 21;
-            label7.Text = "Total Gold : ";
-            // 
-            // GoldLabel
-            // 
-            GoldLabel.AutoSize = true;
-            GoldLabel.Location = new Point(132, 18);
-            GoldLabel.Margin = new Padding(4, 0, 4, 0);
-            GoldLabel.Name = "GoldLabel";
-            GoldLabel.Size = new Size(37, 15);
-            GoldLabel.TabIndex = 22;
-            GoldLabel.Text = "$gold";
-            // 
             // label8
             // 
             label8.AutoSize = true;
-            label8.Location = new Point(12, 95);
+            label8.Location = new Point(8, 57);
             label8.Margin = new Padding(4, 0, 4, 0);
             label8.Name = "label8";
             label8.Size = new Size(69, 15);
@@ -388,7 +360,7 @@
             // CurrentIPLabel
             // 
             CurrentIPLabel.AutoSize = true;
-            CurrentIPLabel.Location = new Point(132, 95);
+            CurrentIPLabel.Location = new Point(128, 57);
             CurrentIPLabel.Margin = new Padding(4, 0, 4, 0);
             CurrentIPLabel.Name = "CurrentIPLabel";
             CurrentIPLabel.Size = new Size(23, 15);
@@ -398,21 +370,17 @@
             // 
             // groupBox4
             // 
-            groupBox4.Controls.Add(label7);
             groupBox4.Controls.Add(CurrentIPLabel);
             groupBox4.Controls.Add(CurrentMapLabel);
             groupBox4.Controls.Add(label8);
             groupBox4.Controls.Add(label5);
-            groupBox4.Controls.Add(GoldLabel);
-            groupBox4.Controls.Add(label4);
-            groupBox4.Controls.Add(PKPointsLabel);
             groupBox4.Controls.Add(OnlineTimeLabel);
             groupBox4.Controls.Add(label6);
-            groupBox4.Location = new Point(7, 178);
+            groupBox4.Location = new Point(7, 285);
             groupBox4.Margin = new Padding(4, 3, 4, 3);
             groupBox4.Name = "groupBox4";
             groupBox4.Padding = new Padding(4, 3, 4, 3);
-            groupBox4.Size = new Size(364, 130);
+            groupBox4.Size = new Size(364, 74);
             groupBox4.TabIndex = 25;
             groupBox4.TabStop = false;
             groupBox4.Text = "Details";
@@ -507,11 +475,84 @@
             label10.TabIndex = 40;
             label10.Text = "Quest Search";
             // 
+            // GameGold
+            // 
+            GameGold.AutoSize = true;
+            GameGold.Font = new Font("Segoe UI", 8F);
+            GameGold.Location = new Point(0, 201);
+            GameGold.Margin = new Padding(4, 0, 4, 0);
+            GameGold.Name = "GameGold";
+            GameGold.Size = new Size(70, 13);
+            GameGold.TabIndex = 22;
+            GameGold.Text = "GameGold : ";
+            // 
+            // GameGoldTextBox
+            // 
+            GameGoldTextBox.Location = new Point(70, 198);
+            GameGoldTextBox.Margin = new Padding(4, 3, 4, 3);
+            GameGoldTextBox.Name = "GameGoldTextBox";
+            GameGoldTextBox.Size = new Size(116, 23);
+            GameGoldTextBox.TabIndex = 23;
+            // 
+            // Gold
+            // 
+            Gold.AutoSize = true;
+            Gold.Location = new Point(10, 172);
+            Gold.Margin = new Padding(4, 0, 4, 0);
+            Gold.Name = "Gold";
+            Gold.Size = new Size(41, 15);
+            Gold.TabIndex = 20;
+            Gold.Text = "Gold : ";
+            // 
+            // GoldTextBox
+            // 
+            GoldTextBox.Location = new Point(70, 169);
+            GoldTextBox.Margin = new Padding(4, 3, 4, 3);
+            GoldTextBox.Name = "GoldTextBox";
+            GoldTextBox.Size = new Size(116, 23);
+            GoldTextBox.TabIndex = 21;
+            // 
+            // PKPoints
+            // 
+            PKPoints.AutoSize = true;
+            PKPoints.Location = new Point(10, 143);
+            PKPoints.Margin = new Padding(4, 0, 4, 0);
+            PKPoints.Name = "PKPoints";
+            PKPoints.Size = new Size(58, 15);
+            PKPoints.TabIndex = 18;
+            PKPoints.Text = "PKPoint : ";
+            // 
+            // PKPointsTextBox
+            // 
+            PKPointsTextBox.Location = new Point(70, 140);
+            PKPointsTextBox.Margin = new Padding(4, 3, 4, 3);
+            PKPointsTextBox.Name = "PKPointsTextBox";
+            PKPointsTextBox.Size = new Size(116, 23);
+            PKPointsTextBox.TabIndex = 19;
+            // 
+            // label12
+            // 
+            label12.AutoSize = true;
+            label12.Location = new Point(10, 114);
+            label12.Margin = new Padding(4, 0, 4, 0);
+            label12.Name = "label12";
+            label12.Size = new Size(36, 15);
+            label12.TabIndex = 16;
+            label12.Text = "EXP : ";
+            // 
+            // ExpTextBox
+            // 
+            ExpTextBox.Location = new Point(70, 111);
+            ExpTextBox.Margin = new Padding(4, 3, 4, 3);
+            ExpTextBox.Name = "ExpTextBox";
+            ExpTextBox.Size = new Size(116, 23);
+            ExpTextBox.TabIndex = 17;
+            // 
             // PlayerInfoForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(544, 378);
+            ClientSize = new Size(544, 424);
             Controls.Add(QuestDown);
             Controls.Add(QuestUp);
             Controls.Add(QuestResultLabel);
@@ -560,12 +601,8 @@
         private System.Windows.Forms.Label CurrentMapLabel;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Button KillPetsButton;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.Label PKPointsLabel;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Label OnlineTimeLabel;
-        private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.Label GoldLabel;
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.Label CurrentIPLabel;
         private System.Windows.Forms.GroupBox groupBox4;
@@ -584,5 +621,13 @@
         private Label QuestResultLabel;
         private TextBox QuestSearchBox;
         private Label label10;
+        private Label GameGold;
+        private TextBox GameGoldTextBox;
+        private Label Gold;
+        private TextBox GoldTextBox;
+        private Label PKPoints;
+        private TextBox PKPointsTextBox;
+        private Label label12;
+        private TextBox ExpTextBox;
     }
 }

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -35,7 +35,7 @@ namespace Server
             IndexTextBox.Text = Character.Index.ToString();
             NameTextBox.Text = Character.Name;
             LevelTextBox.Text = Character.Level.ToString();
-            ExpTextBox.Text = Character.Experience.ToString();
+            ExpTextBox.Text = $"{string.Format("{0:#0.##%}", Character.Player.Experience / (double)Character.Player.MaxExperience)}";
             PKPointsTextBox.Text = Character.PKPoints.ToString();
             GoldTextBox.Text = $"{Character.AccountInfo.Gold:n0}";
             GameGoldTextBox.Text = String.Format("{0:n0}", Character.AccountInfo.Credit);
@@ -81,6 +81,8 @@ namespace Server
 
         private void UpdateButton_Click(object sender, EventArgs e)
         {
+            if (MessageBox.Show("Are you sure you want to Update?", "Update.", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning) != DialogResult.Yes) return;
+
             SaveChanges();
         }
 
@@ -90,11 +92,9 @@ namespace Server
 
             string tempGold = GoldTextBox.Text.Replace(",", "");
             string tempCredit = GameGoldTextBox.Text.Replace(",", "");
-            string tempEXP = ExpTextBox.Text.Replace(",", "");
 
             info.Name = NameTextBox.Text;
             info.Level = Convert.ToByte(LevelTextBox.Text);
-            info.Experience = Convert.ToInt64(tempEXP);
             info.PKPoints = Convert.ToInt32(PKPointsTextBox.Text);
             info.AccountInfo.Gold = Convert.ToUInt32(tempGold);
             info.AccountInfo.Credit = Convert.ToUInt32(tempCredit);

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -26,8 +26,7 @@ namespace Server
 
             Character = SMain.Envir.GetCharacterInfo(player.Name);
 
-            UpdatePlayerInfo();
-            UpdatePetInfo();
+            UpdateTabs();
         }
 
         private void UpdatePlayerInfo()
@@ -63,6 +62,8 @@ namespace Server
 
         private void UpdatePetInfo()
         {
+            ClearPetInfo();
+
             foreach (MonsterObject Pet in Character.Player.Pets)
             {
                 var listItem = new ListViewItem(Pet.Name) { Tag = Pet };
@@ -77,6 +78,161 @@ namespace Server
         private void ClearPetInfo()
         {
             PetView.Items.Clear();
+        }
+
+        private void UpdatePlayerMagics()
+        {
+            MagicListViewNF.Items.Clear();
+
+            for (int i = 0; i < Character.Magics.Count; i++)
+            {
+                UserMagic magic = Character.Magics[i];
+                if (magic == null) continue;
+
+                ListViewItem ListItem = new ListViewItem(magic.Info.Name.ToString()) { Tag = this };
+
+                ListItem.SubItems.Add(magic.Level.ToString());
+
+                switch (magic.Level)
+                {
+                    case 0:
+                        ListItem.SubItems.Add($"{magic.Experience}/{magic.Info.Need1}");
+                        break;
+                    case 1:
+                        ListItem.SubItems.Add($"{magic.Experience}/{magic.Info.Need2}");
+                        break;
+                    case 2:
+                        ListItem.SubItems.Add($"{magic.Experience}/{magic.Info.Need3}");
+                        break;
+                    case 3:
+                        ListItem.SubItems.Add($"-");
+                        break;
+                }
+
+                if (magic.Key > 8)
+                {
+                    var key = magic.Key % 8;
+
+                    ListItem.SubItems.Add(string.Format("CTRL+F{0}", key != 0 ? key : 8));
+                }
+                else if (magic.Key > 0)
+                {
+                    ListItem.SubItems.Add(string.Format("F{0}", magic.Key));
+                }
+                else if (magic.Key == 0)
+                {
+                    ListItem.SubItems.Add(string.Format("No Key", magic.Key));
+                }
+
+                ListItem.SubItems.Add(magic.Key.ToString());
+                MagicListViewNF.Items.Add(ListItem);
+            }
+        }
+
+        private void UpdatePlayerQuests()
+        {
+            QuestInfoListViewNF.Items.Clear();
+
+            foreach (int completedQuestID in Character.CompletedQuests)
+            {
+                // Display the completed quest in the listview
+                ListViewItem item = new ListViewItem(completedQuestID.ToString());
+                item.SubItems.Add("Completed");
+                QuestInfoListViewNF.Items.Add(item);
+            }
+        }
+
+        private void UpdatePlayerItems()
+        {
+            PlayerItemInfoListViewNF.Items.Clear();
+
+            if (Character == null) return;
+
+            for (int i = 0; i < Character.Inventory.Length; i++)
+            {
+                UserItem inventoryItem = Character.Inventory[i];
+
+                if (inventoryItem == null) continue;
+
+                ListViewItem inventoryItemListItem = new ListViewItem($"{inventoryItem.UniqueID}");
+
+                if (i < 6)
+                {
+                    inventoryItemListItem.SubItems.Add($"Belt | Slot: [{i + 1}]");
+                }
+                else if (i >= 6 && i < 46)
+                {
+                    inventoryItemListItem.SubItems.Add($"Inventory Bag I | Slot: [{i - 5}]");
+                }
+                else
+                {
+                    inventoryItemListItem.SubItems.Add($"Inventory Bag II | Slot: [{i - 45}]");
+                }
+
+                inventoryItemListItem.SubItems.Add($"{inventoryItem.FriendlyName}");
+                inventoryItemListItem.SubItems.Add($"{inventoryItem.Count}/{inventoryItem.Info.StackSize}");
+                inventoryItemListItem.SubItems.Add($"{inventoryItem.CurrentDura}/{inventoryItem.MaxDura}");
+
+                PlayerItemInfoListViewNF.Items.Add(inventoryItemListItem);
+            }
+
+
+            for (int i = 0; i < Character.QuestInventory.Length; i++)
+            {
+                UserItem questItem = Character.QuestInventory[i];
+
+                if (questItem == null) continue;
+
+                ListViewItem questItemListItem = new ListViewItem($"{questItem.UniqueID}");
+                questItemListItem.SubItems.Add($"Quest Bag | Slot: [{i + 1}]");
+
+                questItemListItem.SubItems.Add($"{questItem.FriendlyName}");
+                questItemListItem.SubItems.Add($"{questItem.Count}/{questItem.Info.StackSize}");
+                questItemListItem.SubItems.Add($"{questItem.CurrentDura}/{questItem.MaxDura}");
+
+                PlayerItemInfoListViewNF.Items.Add(questItemListItem);
+            }
+
+            for (int i = 0; i < Character.AccountInfo.Storage.Length; i++)
+            {
+                UserItem storeItem = Character.AccountInfo.Storage[i];
+
+                if (storeItem == null) continue;
+
+                ListViewItem storeItemListItem = new ListViewItem($"{storeItem.UniqueID}");
+
+                if (i < 80)
+                {
+                    storeItemListItem.SubItems.Add($"Storage I | Slot: [{i + 1}]");
+                }
+                else
+                {
+                    storeItemListItem.SubItems.Add($"Storage II | Slot: [{i -79}]");
+                }
+
+                storeItemListItem.SubItems.Add($"{storeItem.FriendlyName}");
+                storeItemListItem.SubItems.Add($"{storeItem.Count}/{storeItem.Info.StackSize}");
+                storeItemListItem.SubItems.Add($"{storeItem.CurrentDura}/{storeItem.MaxDura}");
+
+                PlayerItemInfoListViewNF.Items.Add(storeItemListItem);
+            }
+
+            for (int i = 0; i < Character.Equipment.Length; i++)
+            {
+                UserItem equipItem = Character.Equipment[i];
+
+                if (equipItem == null) continue;
+
+                ListViewItem equipItemListItem = new ListViewItem($"{equipItem.UniqueID}");
+
+                equipItemListItem.SubItems.Add($"Equipment | Slot: [{i + 1}]");
+
+                equipItemListItem.SubItems.Add($"{equipItem.FriendlyName}");
+                equipItemListItem.SubItems.Add($"{equipItem.Count}/{equipItem.Info.StackSize}");
+                equipItemListItem.SubItems.Add($"{equipItem.CurrentDura}/{equipItem.MaxDura}");
+
+                PlayerItemInfoListViewNF.Items.Add(equipItemListItem);
+            }
         }
 
         private void UpdateButton_Click(object sender, EventArgs e)
@@ -198,43 +354,23 @@ namespace Server
             }
         }
 
-        private void QuestSearchBox_ValueChanged(object sender, EventArgs e)
+        private void AccountBanButton_Click(object sender, EventArgs e)
         {
-            int questID = 0;
+            if (Character.AccountInfo.AdminAccount) return;
+            Character.AccountInfo.Banned = true;
 
-            if (string.IsNullOrWhiteSpace(QuestSearchBox.Value.ToString()))
-            {
-                QuestResultLabel.Text = string.Empty;
-                return;
-            }
-            else
-            {
-                questID = Decimal.ToInt32(QuestSearchBox.Value);
-            }
+            DateTime date;
 
-            if (questID < 1)
-            {
-                QuestResultLabel.Text = "Invalid Quest Index";
-                QuestResultLabel.ForeColor = Color.Red;
-                return;
-            }
+            DateTime.TryParse(ChatBanExpiryTextBox.Text, out date);
 
-            bool isQuestActive = Character.CurrentQuests.Any(x => x.Index == questID);
-            bool isQuestComplete = Character.CompletedQuests.Contains(questID);
+            Character.AccountInfo.ExpiryDate = date;
 
-            if (isQuestActive)
-            {
-                QuestResultLabel.Text = $"Quest {questID} is Active";
-                QuestResultLabel.ForeColor = Color.Blue;
-            }
-            else
-            {
-                QuestResultLabel.Text = $"Quest {questID} is {(isQuestComplete ? "Completed" : "Inactive")}";
-                QuestResultLabel.ForeColor = isQuestComplete ? Color.Green : Color.Red;
-            }
+            if (Character.Player == null) return;
+
+            Character.Player.Connection.SendDisconnect(6);
         }
 
-        private void FlagSearchBox_ValueChanged(object sender, EventArgs e)
+        private void FlagSearchBox_ValueChanged_1(object sender, EventArgs e)
         {
             int flagIndex = 0;
             if (string.IsNullOrWhiteSpace(FlagSearchBox.Value.ToString()))
@@ -268,21 +404,38 @@ namespace Server
                 ResultLabel.ForeColor = Color.Red;
             }
         }
-
-        private void AccountBanButton_Click(object sender, EventArgs e)
+        
+        private void UpdateTabs()
         {
-            if (Character.AccountInfo.AdminAccount) return;
-            Character.AccountInfo.Banned = true;
+            UpdatePlayerInfo();
+            UpdatePetInfo();
+            UpdatePlayerItems();
+            UpdatePlayerMagics();
+            UpdatePlayerQuests();
+        }
 
-            DateTime date;
+        private void tabControl1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            switch (tabControl1.SelectedIndex)
+            {
+                case 0:
+                    Size = new Size(725, 510);
+                    break;
+                case 1:
+                    Size = new Size(423, 510);
+                    break;
+                case 2:
+                    Size = new Size(597, 510);
+                    break;
+                case 3:
+                    Size = new Size(458, 510);
+                    break;
+                case 4:
+                    Size = new Size(663, 510);
+                    break;
+            }
 
-            DateTime.TryParse(ChatBanExpiryTextBox.Text, out date);
-
-            Character.AccountInfo.ExpiryDate = date;
-
-            if (Character.Player == null) return;
-
-            Character.Player.Connection.SendDisconnect(6);
+            UpdateTabs();
         }
     }
 }

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -34,8 +34,10 @@ namespace Server
             IndexTextBox.Text = Character.Index.ToString();
             NameTextBox.Text = Character.Name;
             LevelTextBox.Text = Character.Level.ToString();
-
-            GoldLabel.Text = $"{Character.AccountInfo.Gold:n0}";
+            ExpTextBox.Text = Character.Experience.ToString();
+            PKPointsTextBox.Text = Character.PKPoints.ToString();
+            GoldTextBox.Text = $"{Character.AccountInfo.Gold:n0}";
+            GameGoldTextBox.Text = String.Format("{0:n0}", Character.AccountInfo.Credit);
 
             if (Character.Player != null)
                 CurrentMapLabel.Text =
@@ -43,7 +45,6 @@ namespace Server
             else
                 CurrentMapLabel.Text = "OFFLINE";
 
-            PKPointsLabel.Text = Character.PKPoints.ToString();
             CurrentIPLabel.Text = Character.AccountInfo.LastIP;
             OnlineTimeLabel.Text = Character.LastLoginDate > Character.LastLogoutDate ? (SMain.Envir.Now - Character.LastLoginDate).TotalMinutes.ToString("##") + " minutes" : "Offline";
 
@@ -59,8 +60,16 @@ namespace Server
         {
             CharacterInfo info = Character;
 
+            string tempGold = GoldTextBox.Text.Replace(",", "");
+            string tempCredit = GameGoldTextBox.Text.Replace(",", "");
+            string tempEXP = ExpTextBox.Text.Replace(",", "");
+
             info.Name = NameTextBox.Text;
             info.Level = Convert.ToByte(LevelTextBox.Text);
+            info.Experience = Convert.ToInt64(tempEXP);
+            info.PKPoints = Convert.ToInt32(PKPointsTextBox.Text);
+            info.AccountInfo.Gold = Convert.ToUInt32(tempGold);
+            info.AccountInfo.Credit = Convert.ToUInt32(tempCredit);
         }
 
         private void SendMessageButton_Click(object sender, EventArgs e)

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -140,6 +140,8 @@ namespace Server
 
         private void ChatBanButton_Click(object sender, EventArgs e)
         {
+            if (Character.AccountInfo.AdminAccount) return;
+
             Character.ChatBanned = true;
 
             DateTime date;
@@ -265,6 +267,22 @@ namespace Server
                 ResultLabel.Text = "Invalid Flag Number";
                 ResultLabel.ForeColor = Color.Red;
             }
+        }
+
+        private void AccountBanButton_Click(object sender, EventArgs e)
+        {
+            if (Character.AccountInfo.AdminAccount) return;
+            Character.AccountInfo.Banned = true;
+
+            DateTime date;
+
+            DateTime.TryParse(ChatBanExpiryTextBox.Text, out date);
+
+            Character.AccountInfo.ExpiryDate = date;
+
+            if (Character.Player == null) return;
+
+            Character.Player.Connection.SendDisconnect(6);
         }
     }
 }

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -27,6 +27,7 @@ namespace Server
             Character = SMain.Envir.GetCharacterInfo(player.Name);
 
             UpdatePlayerInfo();
+            UpdatePetInfo();
         }
 
         private void UpdatePlayerInfo()
@@ -39,6 +40,15 @@ namespace Server
             GoldTextBox.Text = $"{Character.AccountInfo.Gold:n0}";
             GameGoldTextBox.Text = String.Format("{0:n0}", Character.AccountInfo.Credit);
 
+            ACBox.Text = $"{Character.Player.Stats[Stat.MinAC]}-{Character.Player.Stats[Stat.MaxAC]}";
+            AMCBox.Text = $"{Character.Player.Stats[Stat.MinMAC]}-{Character.Player.Stats[Stat.MaxMAC]}";
+            DCBox.Text = $"{Character.Player.Stats[Stat.MinDC]}-{Character.Player.Stats[Stat.MaxDC]}";
+            MCBox.Text = $"{Character.Player.Stats[Stat.MinMC]}-{Character.Player.Stats[Stat.MaxMC]}";
+            SCBox.Text = $"{Character.Player.Stats[Stat.MinSC]}-{Character.Player.Stats[Stat.MaxSC]}";
+            ACCBox.Text = $"{Character.Player.Stats[Stat.Accuracy]}";
+            AGILBox.Text = $"{Character.Player.Stats[Stat.Agility]}";
+            ATKSPDBox.Text = $"{Character.Player.Stats[Stat.AttackSpeed]}";
+
             if (Character.Player != null)
                 CurrentMapLabel.Text =
                     $"{Character.Player.CurrentMap.Info.Title} {Character.Player.CurrentMap.Info.FileName} {Character.CurrentLocation.X}:{Character.CurrentLocation.Y}";
@@ -49,6 +59,24 @@ namespace Server
             OnlineTimeLabel.Text = Character.LastLoginDate > Character.LastLogoutDate ? (SMain.Envir.Now - Character.LastLoginDate).TotalMinutes.ToString("##") + " minutes" : "Offline";
 
             ChatBanExpiryTextBox.Text = Character.ChatBanExpiryDate.ToString();
+        }
+
+        private void UpdatePetInfo()
+        {
+            foreach (MonsterObject Pet in Character.Player.Pets)
+            {
+                var listItem = new ListViewItem(Pet.Name) { Tag = Pet };
+                listItem.SubItems.Add(Pet.PetLevel.ToString());
+                listItem.SubItems.Add($"{Pet.Health}/{Pet.MaxHealth}");
+                listItem.SubItems.Add($"Map: {Pet.CurrentMap.Info.Title}, X: {Pet.CurrentLocation.X}, Y: {Pet.CurrentLocation.Y}");
+
+                PetView.Items.Add(listItem);
+            }
+        }
+
+        private void ClearPetInfo()
+        {
+            PetView.Items.Clear();
         }
 
         private void UpdateButton_Click(object sender, EventArgs e)
@@ -102,6 +130,8 @@ namespace Server
 
             for (int i = Character.Player.Pets.Count - 1; i >= 0; i--)
                 Character.Player.Pets[i].Die();
+
+            ClearPetInfo();
         }
         private void SafeZoneButton_Click(object sender, EventArgs e)
         {
@@ -142,132 +172,8 @@ namespace Server
             form.ShowDialog();
         }
 
-        private void FlagSearchBox_TextChanged(object sender, EventArgs e)
-        {
-            TextBox flagTextBox = (TextBox)sender;
 
-            if (string.IsNullOrWhiteSpace(flagTextBox.Text))
-            {
-                ResultLabel.Text = string.Empty;
-                return;
-            }
 
-            if (int.TryParse(flagTextBox.Text, out int flagIndex))
-            {
-                if (flagIndex >= 0 && flagIndex < Character.Flags.Length)
-                {
-                    bool flagValue = Character.Flags[flagIndex];
-
-                    if (flagValue)
-                    {
-                        ResultLabel.Text = $"Flag {flagIndex} is Active";
-                        ResultLabel.ForeColor = Color.Green;
-                    }
-                    else
-                    {
-                        ResultLabel.Text = $"Flag {flagIndex} is Inactive";
-                        ResultLabel.ForeColor = Color.Red;
-                    }
-                }
-                else
-                {
-                    ResultLabel.Text = "Invalid Flag Number";
-                    ResultLabel.ForeColor = Color.Red;
-                }
-            }
-        }
-
-        private void FlagUp_Click(object sender, EventArgs e)
-        {
-            if (int.TryParse(FlagSearchBox.Text, out int currentValue))
-            {
-                int newValue = currentValue + 1;
-
-                FlagSearchBox.Text = newValue.ToString();
-            }
-            else
-            {
-                FlagSearchBox.Text = "1";
-            }
-        }
-
-        private void FlagDown_Click(object sender, EventArgs e)
-        {
-            if (int.TryParse(FlagSearchBox.Text, out int currentValue))
-            {
-                int newValue = currentValue - 1;
-
-                newValue = Math.Max(0, newValue);
-
-                FlagSearchBox.Text = newValue.ToString();
-            }
-        }
-
-        private void QuestSearchBox_TextChanged(object sender, EventArgs e)
-        {
-            TextBox questTextBox = (TextBox)sender;
-
-            if (string.IsNullOrWhiteSpace(questTextBox.Text))
-            {
-                QuestResultLabel.Text = string.Empty;
-                return;
-            }
-
-            if (int.TryParse(questTextBox.Text, out int questID))
-            {
-                if (questID < 1)
-                {
-                    QuestResultLabel.Text = "Invalid Quest Index";
-                    QuestResultLabel.ForeColor = Color.Red;
-                    return;
-                }
-
-                bool isQuestActive = Character.CurrentQuests.Any(x => x.Index == questID);
-                bool isQuestComplete = Character.CompletedQuests.Contains(questID);
-
-                if (isQuestActive)
-                {
-                    QuestResultLabel.Text = $"Quest {questID} is Active";
-                    QuestResultLabel.ForeColor = Color.Blue;
-                }
-                else
-                {
-                    QuestResultLabel.Text = $"Quest {questID} is {(isQuestComplete ? "Completed" : "Not Picked-up")}";
-                    QuestResultLabel.ForeColor = isQuestComplete ? Color.Green : Color.Red;
-                }
-            }
-            else
-            {
-                QuestResultLabel.Text = "Invalid Quest Index";
-                QuestResultLabel.ForeColor = Color.Red;
-            }
-        }
-
-        private void QuestUp_Click(object sender, EventArgs e)
-        {
-            if (int.TryParse(QuestSearchBox.Text, out int currentValue))
-            {
-                int newValue = currentValue + 1;
-
-                QuestSearchBox.Text = newValue.ToString();
-            }
-            else
-            {
-                QuestSearchBox.Text = "1";
-            }
-        }
-
-        private void QuestDown_Click(object sender, EventArgs e)
-        {
-            if (int.TryParse(QuestSearchBox.Text, out int currentValue))
-            {
-                int newValue = currentValue - 1;
-
-                newValue = Math.Max(0, newValue);
-
-                QuestSearchBox.Text = newValue.ToString();
-            }
-        }
 
         private void CurrentIPLabel_Click(object sender, EventArgs e)
         {
@@ -287,6 +193,77 @@ namespace Server
             catch (Exception ex)
             {
                 MessageBox.Show($"Error opening URL: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void QuestSearchBox_ValueChanged(object sender, EventArgs e)
+        {
+            int questID = 0;
+
+            if (string.IsNullOrWhiteSpace(QuestSearchBox.Value.ToString()))
+            {
+                QuestResultLabel.Text = string.Empty;
+                return;
+            }
+            else
+            {
+                questID = Decimal.ToInt32(QuestSearchBox.Value);
+            }
+
+            if (questID < 1)
+            {
+                QuestResultLabel.Text = "Invalid Quest Index";
+                QuestResultLabel.ForeColor = Color.Red;
+                return;
+            }
+
+            bool isQuestActive = Character.CurrentQuests.Any(x => x.Index == questID);
+            bool isQuestComplete = Character.CompletedQuests.Contains(questID);
+
+            if (isQuestActive)
+            {
+                QuestResultLabel.Text = $"Quest {questID} is Active";
+                QuestResultLabel.ForeColor = Color.Blue;
+            }
+            else
+            {
+                QuestResultLabel.Text = $"Quest {questID} is {(isQuestComplete ? "Completed" : "Inactive")}";
+                QuestResultLabel.ForeColor = isQuestComplete ? Color.Green : Color.Red;
+            }
+        }
+
+        private void FlagSearchBox_ValueChanged(object sender, EventArgs e)
+        {
+            int flagIndex = 0;
+            if (string.IsNullOrWhiteSpace(FlagSearchBox.Value.ToString()))
+            {
+                ResultLabel.Text = string.Empty;
+                return;
+            }
+            else
+            {
+                flagIndex = Decimal.ToInt32(FlagSearchBox.Value);
+            }
+
+            if (flagIndex >= 0 && flagIndex < Character.Flags.Length)
+            {
+                bool flagValue = Character.Flags[flagIndex];
+
+                if (flagValue)
+                {
+                    ResultLabel.Text = $"Flag {flagIndex} is Active";
+                    ResultLabel.ForeColor = Color.Green;
+                }
+                else
+                {
+                    ResultLabel.Text = $"Flag {flagIndex} is Inactive";
+                    ResultLabel.ForeColor = Color.Red;
+                }
+            }
+            else
+            {
+                ResultLabel.Text = "Invalid Flag Number";
+                ResultLabel.ForeColor = Color.Red;
             }
         }
     }

--- a/Server.MirForms/Database/MapInfoForm.cs
+++ b/Server.MirForms/Database/MapInfoForm.cs
@@ -6,7 +6,7 @@ namespace Server
     public partial class MapInfoForm : Form
     {
         public Envir Envir => SMain.EditEnvir;
-
+      
         private List<MapInfo> _selectedMapInfos;
         private List<SafeZoneInfo> _selectedSafeZoneInfos;
         private List<RespawnInfo> _selectedRespawnInfos;

--- a/Server.MirForms/Database/MapInfoForm.resx
+++ b/Server.MirForms/Database/MapInfoForm.resx
@@ -120,7 +120,4 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/Server.MirForms/SMain.Designer.cs
+++ b/Server.MirForms/SMain.Designer.cs
@@ -52,6 +52,14 @@ namespace Server
             levelHeader = new ColumnHeader();
             classHeader = new ColumnHeader();
             genderHeader = new ColumnHeader();
+            tabPage5 = new TabPage();
+            GuildListView = new CustomFormControl.ListViewNF();
+            columnHeader1 = new ColumnHeader();
+            columnHeader2 = new ColumnHeader();
+            columnHeader3 = new ColumnHeader();
+            columnHeader4 = new ColumnHeader();
+            columnHeader5 = new ColumnHeader();
+            columnHeader6 = new ColumnHeader();
             StatusBar = new StatusStrip();
             PlayersLabel = new ToolStripStatusLabel();
             MonsterLabel = new ToolStripStatusLabel();
@@ -107,6 +115,7 @@ namespace Server
             tabPage3.SuspendLayout();
             groupBox1.SuspendLayout();
             tabPage4.SuspendLayout();
+            tabPage5.SuspendLayout();
             StatusBar.SuspendLayout();
             MainMenu.SuspendLayout();
             SuspendLayout();
@@ -117,6 +126,7 @@ namespace Server
             MainTabs.Controls.Add(tabPage2);
             MainTabs.Controls.Add(tabPage3);
             MainTabs.Controls.Add(tabPage4);
+            MainTabs.Controls.Add(tabPage5);
             MainTabs.Dock = DockStyle.Fill;
             MainTabs.Location = new Point(0, 24);
             MainTabs.Margin = new Padding(4, 3, 4, 3);
@@ -124,6 +134,7 @@ namespace Server
             MainTabs.SelectedIndex = 0;
             MainTabs.Size = new Size(566, 407);
             MainTabs.TabIndex = 5;
+            MainTabs.Click += MainTabs_Click;
             // 
             // tabPage1
             // 
@@ -286,6 +297,61 @@ namespace Server
             genderHeader.Text = "Gender";
             genderHeader.Width = 98;
             // 
+            // tabPage5
+            // 
+            tabPage5.Controls.Add(GuildListView);
+            tabPage5.Location = new Point(4, 24);
+            tabPage5.Name = "tabPage5";
+            tabPage5.Padding = new Padding(3);
+            tabPage5.Size = new Size(558, 379);
+            tabPage5.TabIndex = 4;
+            tabPage5.Text = "Guilds";
+            tabPage5.UseVisualStyleBackColor = true;
+            // 
+            // GuildListView
+            // 
+            GuildListView.Activation = ItemActivation.OneClick;
+            GuildListView.Columns.AddRange(new ColumnHeader[] { columnHeader1, columnHeader2, columnHeader3, columnHeader4, columnHeader5, columnHeader6 });
+            GuildListView.Dock = DockStyle.Fill;
+            GuildListView.FullRowSelect = true;
+            GuildListView.GridLines = true;
+            GuildListView.Location = new Point(3, 3);
+            GuildListView.Name = "GuildListView";
+            GuildListView.Size = new Size(552, 373);
+            GuildListView.TabIndex = 1;
+            GuildListView.UseCompatibleStateImageBehavior = false;
+            GuildListView.View = View.Details;
+            GuildListView.DoubleClick += GuildListView_DoubleClick;
+            // 
+            // columnHeader1
+            // 
+            columnHeader1.Text = "Index";
+            // 
+            // columnHeader2
+            // 
+            columnHeader2.Text = "Name";
+            columnHeader2.Width = 115;
+            // 
+            // columnHeader3
+            // 
+            columnHeader3.Text = "Leader";
+            columnHeader3.Width = 130;
+            // 
+            // columnHeader4
+            // 
+            columnHeader4.Text = "Member Count";
+            columnHeader4.Width = 100;
+            // 
+            // columnHeader5
+            // 
+            columnHeader5.Text = "Level";
+            columnHeader5.Width = 75;
+            // 
+            // columnHeader6
+            // 
+            columnHeader6.Text = "Gold";
+            columnHeader6.Width = 75;
+            // 
             // StatusBar
             // 
             StatusBar.Items.AddRange(new ToolStripItem[] { PlayersLabel, MonsterLabel, ConnectionsLabel, BlockedIPsLabel, CycleDelayLabel });
@@ -352,45 +418,45 @@ namespace Server
             // startServerToolStripMenuItem
             // 
             startServerToolStripMenuItem.Name = "startServerToolStripMenuItem";
-            startServerToolStripMenuItem.Size = new Size(180, 22);
+            startServerToolStripMenuItem.Size = new Size(164, 22);
             startServerToolStripMenuItem.Text = "Start Server";
             startServerToolStripMenuItem.Click += startServerToolStripMenuItem_Click;
             // 
             // stopServerToolStripMenuItem
             // 
             stopServerToolStripMenuItem.Name = "stopServerToolStripMenuItem";
-            stopServerToolStripMenuItem.Size = new Size(180, 22);
+            stopServerToolStripMenuItem.Size = new Size(164, 22);
             stopServerToolStripMenuItem.Text = "Stop Server";
             stopServerToolStripMenuItem.Click += stopServerToolStripMenuItem_Click;
             // 
             // rebootServerToolStripMenuItem
             // 
             rebootServerToolStripMenuItem.Name = "rebootServerToolStripMenuItem";
-            rebootServerToolStripMenuItem.Size = new Size(180, 22);
+            rebootServerToolStripMenuItem.Size = new Size(164, 22);
             rebootServerToolStripMenuItem.Text = "Reboot Server";
             rebootServerToolStripMenuItem.Click += rebootServerToolStripMenuItem_Click;
             // 
             // clearBlockedIPsToolStripMenuItem
             // 
             clearBlockedIPsToolStripMenuItem.Name = "clearBlockedIPsToolStripMenuItem";
-            clearBlockedIPsToolStripMenuItem.Size = new Size(180, 22);
+            clearBlockedIPsToolStripMenuItem.Size = new Size(164, 22);
             clearBlockedIPsToolStripMenuItem.Text = "Clear Blocked IPs";
             clearBlockedIPsToolStripMenuItem.Click += clearBlockedIPsToolStripMenuItem_Click;
             // 
             // toolStripMenuItem1
             // 
             toolStripMenuItem1.Name = "toolStripMenuItem1";
-            toolStripMenuItem1.Size = new Size(177, 6);
+            toolStripMenuItem1.Size = new Size(161, 6);
             // 
             // toolStripSeparator1
             // 
             toolStripSeparator1.Name = "toolStripSeparator1";
-            toolStripSeparator1.Size = new Size(177, 6);
+            toolStripSeparator1.Size = new Size(161, 6);
             // 
             // closeServerToolStripMenuItem
             // 
             closeServerToolStripMenuItem.Name = "closeServerToolStripMenuItem";
-            closeServerToolStripMenuItem.Size = new Size(180, 22);
+            closeServerToolStripMenuItem.Size = new Size(164, 22);
             closeServerToolStripMenuItem.Text = "Close Server";
             closeServerToolStripMenuItem.Click += closeServerToolStripMenuItem_Click;
             // 
@@ -398,27 +464,27 @@ namespace Server
             // 
             reloadToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { nPCsToolStripMenuItem, dropsToolStripMenuItem, lineMessageToolStripMenuItem });
             reloadToolStripMenuItem.Name = "reloadToolStripMenuItem";
-            reloadToolStripMenuItem.Size = new Size(180, 22);
+            reloadToolStripMenuItem.Size = new Size(164, 22);
             reloadToolStripMenuItem.Text = "Reload";
             // 
             // nPCsToolStripMenuItem
             // 
             nPCsToolStripMenuItem.Name = "nPCsToolStripMenuItem";
-            nPCsToolStripMenuItem.Size = new Size(180, 22);
+            nPCsToolStripMenuItem.Size = new Size(145, 22);
             nPCsToolStripMenuItem.Text = "NPCs";
             nPCsToolStripMenuItem.Click += nPCsToolStripMenuItem_Click;
             // 
             // dropsToolStripMenuItem
             // 
             dropsToolStripMenuItem.Name = "dropsToolStripMenuItem";
-            dropsToolStripMenuItem.Size = new Size(180, 22);
+            dropsToolStripMenuItem.Size = new Size(145, 22);
             dropsToolStripMenuItem.Text = "Drops";
             dropsToolStripMenuItem.Click += dropsToolStripMenuItem_Click;
             // 
             // lineMessageToolStripMenuItem
             // 
             lineMessageToolStripMenuItem.Name = "lineMessageToolStripMenuItem";
-            lineMessageToolStripMenuItem.Size = new Size(180, 22);
+            lineMessageToolStripMenuItem.Size = new Size(145, 22);
             lineMessageToolStripMenuItem.Text = "Line Message";
             lineMessageToolStripMenuItem.Click += lineMessageToolStripMenuItem_Click;
             // 
@@ -659,6 +725,7 @@ namespace Server
             groupBox1.ResumeLayout(false);
             groupBox1.PerformLayout();
             tabPage4.ResumeLayout(false);
+            tabPage5.ResumeLayout(false);
             StatusBar.ResumeLayout(false);
             StatusBar.PerformLayout();
             MainMenu.ResumeLayout(false);
@@ -735,6 +802,14 @@ namespace Server
         private ToolStripMenuItem nPCsToolStripMenuItem;
         private ToolStripMenuItem dropsToolStripMenuItem;
         private ToolStripMenuItem lineMessageToolStripMenuItem;
+        private TabPage tabPage5;
+        private CustomFormControl.ListViewNF GuildListView;
+        private ColumnHeader columnHeader1;
+        private ColumnHeader columnHeader2;
+        private ColumnHeader columnHeader3;
+        private ColumnHeader columnHeader4;
+        private ColumnHeader columnHeader5;
+        private ColumnHeader columnHeader6;
     }
 }
 

--- a/Server.MirForms/Server.csproj.user
+++ b/Server.MirForms/Server.csproj.user
@@ -55,6 +55,9 @@
     <Compile Update="Systems\GuildInfoForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Update="Systems\GuildItemForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="Systems\MiningInfoForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Server.MirForms/Systems/GuildItemForm.Designer.cs
+++ b/Server.MirForms/Systems/GuildItemForm.Designer.cs
@@ -1,0 +1,136 @@
+﻿namespace Server.Systems
+{
+    partial class GuildItemForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            GuildItemListView = new ListView();
+            indexHeader = new ColumnHeader();
+            PlaceHeader = new ColumnHeader();
+            nameHeader = new ColumnHeader();
+            countHeader = new ColumnHeader();
+            DuraHeader = new ColumnHeader();
+            MemberListView = new ListView();
+            Members = new ColumnHeader();
+            Rank = new ColumnHeader();
+            DeleteButton = new Button();
+            SuspendLayout();
+            // 
+            // GuildItemListView
+            // 
+            GuildItemListView.Columns.AddRange(new ColumnHeader[] { indexHeader, PlaceHeader, nameHeader, countHeader, DuraHeader });
+            GuildItemListView.GridLines = true;
+            GuildItemListView.Location = new Point(1, 0);
+            GuildItemListView.Name = "GuildItemListView";
+            GuildItemListView.Size = new Size(520, 414);
+            GuildItemListView.TabIndex = 0;
+            GuildItemListView.UseCompatibleStateImageBehavior = false;
+            GuildItemListView.View = View.Details;
+            // 
+            // indexHeader
+            // 
+            indexHeader.Text = "UID";
+            indexHeader.Width = 70;
+            // 
+            // PlaceHeader
+            // 
+            PlaceHeader.Text = "Stored By";
+            PlaceHeader.Width = 130;
+            // 
+            // nameHeader
+            // 
+            nameHeader.Text = "Name";
+            nameHeader.Width = 115;
+            // 
+            // countHeader
+            // 
+            countHeader.Text = "Count";
+            countHeader.Width = 95;
+            // 
+            // DuraHeader
+            // 
+            DuraHeader.Text = "Dura";
+            DuraHeader.Width = 155;
+            // 
+            // MemberListView
+            // 
+            MemberListView.Columns.AddRange(new ColumnHeader[] { Members, Rank });
+            MemberListView.GridLines = true;
+            MemberListView.Location = new Point(547, 12);
+            MemberListView.Name = "MemberListView";
+            MemberListView.Scrollable = false;
+            MemberListView.Size = new Size(291, 323);
+            MemberListView.TabIndex = 1;
+            MemberListView.UseCompatibleStateImageBehavior = false;
+            MemberListView.View = View.Details;
+            // 
+            // Members
+            // 
+            Members.Text = "Members";
+            Members.Width = 195;
+            // 
+            // Rank
+            // 
+            Rank.Text = "Ranks";
+            Rank.Width = 180;
+            // 
+            // DeleteButton
+            // 
+            DeleteButton.Location = new Point(654, 356);
+            DeleteButton.Name = "DeleteButton";
+            DeleteButton.Size = new Size(75, 32);
+            DeleteButton.TabIndex = 2;
+            DeleteButton.Text = "Delete";
+            DeleteButton.UseVisualStyleBackColor = true;
+            DeleteButton.Click += DeleteButton_Click;
+            // 
+            // GuildItemForm
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(854, 450);
+            Controls.Add(DeleteButton);
+            Controls.Add(MemberListView);
+            Controls.Add(GuildItemListView);
+            Name = "GuildItemForm";
+            Text = "GuildItemForm";
+            ResumeLayout(false);
+        }
+
+        #endregion
+        private ColumnHeader indexHeader;
+        private ColumnHeader PlaceHeader;
+        private ColumnHeader nameHeader;
+        private ColumnHeader countHeader;
+        private ColumnHeader DuraHeader;
+        private ColumnHeader Members;
+        private ColumnHeader Rank;
+        private Button DeleteButton;
+        public ListView GuildItemListView;
+        public ListView MemberListView;
+    }
+}

--- a/Server.MirForms/Systems/GuildItemForm.cs
+++ b/Server.MirForms/Systems/GuildItemForm.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Server.Systems
+{
+    public partial class GuildItemForm : Form
+    {
+        public string GuildName;
+        public SMain main;
+
+        public GuildItemForm()
+        {
+            InitializeComponent();
+        }
+
+        private void DeleteButton_Click(object sender, EventArgs e)
+        {
+            if (MemberListView == null) return;
+            if (MemberListView.SelectedItems == null) return;
+
+            Server.MirObjects.GuildObject Guild = SMain.Envir.GetGuild(GuildName);
+            if (Guild == null) return;
+
+            foreach (var m in MemberListView.SelectedItems)
+            {
+                var lm = (ListViewItem)m;
+
+                Guild.DeleteMember(lm.SubItems[0].Text);
+                MemberListView.Items.Remove(lm);
+                main.ProcessGuildViewTab();
+                break;
+            }
+        }
+    }
+}

--- a/Server.MirForms/Systems/GuildItemForm.resx
+++ b/Server.MirForms/Systems/GuildItemForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Server/MirDatabase/GuildInfo.cs
+++ b/Server/MirDatabase/GuildInfo.cs
@@ -57,7 +57,7 @@ namespace Server.MirDatabase
             if (Name == Settings.NewbieGuild)
             {
                 MemberCap = Settings.NewbieGuildMaxSize;
-                Level = 1;
+                Level = 21;
             }
             else if(Level < Settings.Guild_MembercapList.Count)
             {

--- a/Server/MirObjects/GuildObject.cs
+++ b/Server/MirObjects/GuildObject.cs
@@ -444,6 +444,34 @@ namespace Server.MirObjects
             return true;
         }
 
+        public void DeleteMember(string name)
+        {//carefull this can lead to guild with no ranks or members(or no leader)
+            
+            GuildMember Member = null;
+            GuildRank MemberRank = null;
+            for (int i = 0; i < Ranks.Count; i++)
+                for (int j = 0; j < Ranks[i].Members.Count; j++)
+                {
+
+                    Member = Ranks[i].Members[j];
+                    MemberRank = Ranks[i];
+
+                    if (Member.Name != name) continue;
+
+                    MemberDeleted(Member.Name, (PlayerObject)Member.Player, true);
+                    if (Member.Player != null)
+                    {
+                        PlayerObject LeavingMember = (PlayerObject)Member.Player;
+                        LeavingMember.RefreshStats();
+                    }
+                    MemberRank.Members.Remove(Member);
+                    NeedSave = true;
+                    Info.Membercount--;
+
+                    break;
+                }
+        }
+
         public void MemberDeleted(string name, PlayerObject formerMember, bool kickSelf)
         {
             for (int i = 0; i < Ranks.Count; i++)

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -422,6 +422,8 @@ namespace Server.MirObjects
                     return string.Format("{0} Has logged out. Reason: Kicked by admin", Name);
                 case 5:
                     return string.Format("{0} Has logged out. Reason: Maximum connections reached", Name);
+                case 6:
+                    return string.Format("{0} Has logged out. Reason: Account has been Banned!", Name);
                 case 10:
                     return string.Format("{0} Has logged out. Reason: Wrong client version", Name);
                 case 20:


### PR DESCRIPTION
-PlayerInfoForm

* 'SendMessageButton' Button location adjusted to match heigh of 'SendMessageTextBox'.
* Stats Label has a space between STAT & :
* 'Update' Button text has been realigned.
* 'AccountBanButton' spelling mistake fixed.
* Quest Search Removed.
* GuildItemForm added. (Double click guild in 'Guilds' tab to view)
* Guilds Tab added to Smain.
* Pet View relocated to it's own 'Pet Info' Tab.
* Player Magic View added.
* Player Items View added.
* Player Quest View added.

Overall: PlayerInfoForm now has alot more information to view to allow server owners to monitor.


-Misc

*Newbie Guild Level Set to 21 as a default. Please Set Cap=1000 for Level=21 in GuildSettings.ini. (Server>Configs)