### PR TITLE
Crash Fixes for PlayerInfoForm

### DIFF
--- a/Server.MirForms/Account/AccountInfoForm.cs
+++ b/Server.MirForms/Account/AccountInfoForm.cs
@@ -537,6 +537,7 @@ namespace Server
             AccountInfoListView.EndUpdate();
         }
 
+        #region IPSearch
         private void CreationIPSearch_Click(object sender, EventArgs e)
         {
             string ipAddress = CreationIPTextBox.Text;
@@ -576,5 +577,6 @@ namespace Server
                 MessageBox.Show($"Error opening URL: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
+        #endregion
     }
 }

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -32,28 +32,36 @@ namespace Server
         #region PlayerInfo
         private void UpdatePlayerInfo()
         {
-            IndexTextBox.Text = Character.Index.ToString();
+
+            if (Character == null) return;
+            if (Character.Player == null) return;
+
+                IndexTextBox.Text = Character.Index.ToString();
             NameTextBox.Text = Character.Name;
             LevelTextBox.Text = Character.Level.ToString();
-            ExpTextBox.Text = $"{string.Format("{0:#0.##%}", Character.Player.Experience / (double)Character.Player.MaxExperience)}";
             PKPointsTextBox.Text = Character.PKPoints.ToString();
             GoldTextBox.Text = $"{Character.AccountInfo.Gold:n0}";
             GameGoldTextBox.Text = String.Format("{0:n0}", Character.AccountInfo.Credit);
 
-            ACBox.Text = $"{Character.Player.Stats[Stat.MinAC]}-{Character.Player.Stats[Stat.MaxAC]}";
-            AMCBox.Text = $"{Character.Player.Stats[Stat.MinMAC]}-{Character.Player.Stats[Stat.MaxMAC]}";
-            DCBox.Text = $"{Character.Player.Stats[Stat.MinDC]}-{Character.Player.Stats[Stat.MaxDC]}";
-            MCBox.Text = $"{Character.Player.Stats[Stat.MinMC]}-{Character.Player.Stats[Stat.MaxMC]}";
-            SCBox.Text = $"{Character.Player.Stats[Stat.MinSC]}-{Character.Player.Stats[Stat.MaxSC]}";
-            ACCBox.Text = $"{Character.Player.Stats[Stat.Accuracy]}";
-            AGILBox.Text = $"{Character.Player.Stats[Stat.Agility]}";
-            ATKSPDBox.Text = $"{Character.Player.Stats[Stat.AttackSpeed]}";
 
             if (Character.Player != null)
-                CurrentMapLabel.Text =
-                    $"{Character.Player.CurrentMap.Info.Title} {Character.Player.CurrentMap.Info.FileName} {Character.CurrentLocation.X}:{Character.CurrentLocation.Y}";
+            {
+                CurrentMapLabel.Text = $"{Character.Player.CurrentMap.Info.Title} {Character.Player.CurrentMap.Info.FileName} {Character.CurrentLocation.X}:{Character.CurrentLocation.Y}";
+
+                ExpTextBox.Text = $"{string.Format("{0:#0.##%}", Character.Player.Experience / (double)Character.Player.MaxExperience)}";
+                ACBox.Text = $"{Character.Player.Stats[Stat.MinAC]}-{Character.Player.Stats[Stat.MaxAC]}";
+                AMCBox.Text = $"{Character.Player.Stats[Stat.MinMAC]}-{Character.Player.Stats[Stat.MaxMAC]}";
+                DCBox.Text = $"{Character.Player.Stats[Stat.MinDC]}-{Character.Player.Stats[Stat.MaxDC]}";
+                MCBox.Text = $"{Character.Player.Stats[Stat.MinMC]}-{Character.Player.Stats[Stat.MaxMC]}";
+                SCBox.Text = $"{Character.Player.Stats[Stat.MinSC]}-{Character.Player.Stats[Stat.MaxSC]}";
+                ACCBox.Text = $"{Character.Player.Stats[Stat.Accuracy]}";
+                AGILBox.Text = $"{Character.Player.Stats[Stat.Agility]}";
+                ATKSPDBox.Text = $"{Character.Player.Stats[Stat.AttackSpeed]}";
+            }
             else
+            {
                 CurrentMapLabel.Text = "OFFLINE";
+            }
 
             CurrentIPLabel.Text = Character.AccountInfo.LastIP;
             OnlineTimeLabel.Text = Character.LastLoginDate > Character.LastLogoutDate ? (SMain.Envir.Now - Character.LastLoginDate).TotalMinutes.ToString("##") + " minutes" : "Offline";
@@ -66,6 +74,9 @@ namespace Server
         private void UpdatePetInfo()
         {
             ClearPetInfo();
+
+            if (Character == null) return;
+            if (Character.Player == null) return;
 
             foreach (MonsterObject Pet in Character.Player.Pets)
             {
@@ -248,6 +259,9 @@ namespace Server
         #region Buttons
         private void UpdateButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
+            if (Character.Player == null) return;
+
             if (MessageBox.Show("Are you sure you want to Update?", "Update.", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning) != DialogResult.Yes) return;
 
             SaveChanges();
@@ -265,10 +279,13 @@ namespace Server
             info.PKPoints = Convert.ToInt32(PKPointsTextBox.Text);
             info.AccountInfo.Gold = Convert.ToUInt32(tempGold);
             info.AccountInfo.Credit = Convert.ToUInt32(tempCredit);
+
+            UpdateTabs();
         }
 
         private void SendMessageButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
             if (Character.Player == null) return;
 
             if (SendMessageTextBox.Text.Length < 1) return;
@@ -278,6 +295,7 @@ namespace Server
 
         private void KickButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
             if (Character.Player == null) return;
 
             Character.Player.Connection.SendDisconnect(4);
@@ -286,6 +304,7 @@ namespace Server
 
         private void KillButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
             if (Character.Player == null) return;
 
             Character.Player.Die();
@@ -293,6 +312,7 @@ namespace Server
 
         private void KillPetsButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
             if (Character.Player == null) return;
 
             for (int i = Character.Player.Pets.Count - 1; i >= 0; i--)
@@ -302,11 +322,16 @@ namespace Server
         }
         private void SafeZoneButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
+            if (Character.Player == null) return;
+
             Character.Player.Teleport(SMain.Envir.GetMap(Character.BindMapIndex), Character.BindLocation);
         }
 
         private void ChatBanButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
+            if (Character.Player == null) return;
             if (Character.AccountInfo.AdminAccount) return;
 
             Character.ChatBanned = true;
@@ -334,6 +359,9 @@ namespace Server
 
         private void OpenAccountButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
+            if (Character.Player == null) return;
+
             string accountId = Character.AccountInfo.AccountID;
 
             AccountInfoForm form = new AccountInfoForm(accountId, true);
@@ -364,7 +392,10 @@ namespace Server
 
         private void AccountBanButton_Click(object sender, EventArgs e)
         {
+            if (Character == null) return;
+            if (Character.Player == null) return;
             if (Character.AccountInfo.AdminAccount) return;
+
             Character.AccountInfo.Banned = true;
 
             DateTime date;
@@ -373,7 +404,6 @@ namespace Server
 
             Character.AccountInfo.ExpiryDate = date;
 
-            if (Character.Player == null) return;
 
             Character.Player.Connection.SendDisconnect(6);
         }

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -254,8 +254,6 @@ namespace Server
         #region Buttons
         private void UpdateButton_Click(object sender, EventArgs e)
         {
-            if (Character?.Player == null) return;
-
             if (MessageBox.Show("Are you sure you want to Update?", "Update.", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning) != DialogResult.Yes) return;
 
             SaveChanges();
@@ -347,8 +345,6 @@ namespace Server
 
         private void OpenAccountButton_Click(object sender, EventArgs e)
         {
-            if (Character?.Player == null) return;
-
             string accountId = Character.AccountInfo.AccountID;
 
             AccountInfoForm form = new AccountInfoForm(accountId, true);
@@ -379,7 +375,6 @@ namespace Server
 
         private void AccountBanButton_Click(object sender, EventArgs e)
         {
-            if (Character?.Player == null) return;
             if (Character.AccountInfo.AdminAccount) return;
 
             Character.AccountInfo.Banned = true;
@@ -390,8 +385,10 @@ namespace Server
 
             Character.AccountInfo.ExpiryDate = date;
 
-
-            Character.Player.Connection.SendDisconnect(6);
+            if (Character?.Player != null)
+            {
+                Character.Player.Connection.SendDisconnect(6);
+            }
         }
         #endregion
 

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -29,6 +29,7 @@ namespace Server
             UpdateTabs();
         }
 
+        #region PlayerInfo
         private void UpdatePlayerInfo()
         {
             IndexTextBox.Text = Character.Index.ToString();
@@ -59,7 +60,9 @@ namespace Server
 
             ChatBanExpiryTextBox.Text = Character.ChatBanExpiryDate.ToString();
         }
+        #endregion
 
+        #region PlayerPets
         private void UpdatePetInfo()
         {
             ClearPetInfo();
@@ -79,7 +82,9 @@ namespace Server
         {
             PetView.Items.Clear();
         }
+        #endregion
 
+        #region PlayerMagics
         private void UpdatePlayerMagics()
         {
             MagicListViewNF.Items.Clear();
@@ -128,7 +133,9 @@ namespace Server
                 MagicListViewNF.Items.Add(ListItem);
             }
         }
+        #endregion
 
+        #region PlayerQuests
         private void UpdatePlayerQuests()
         {
             QuestInfoListViewNF.Items.Clear();
@@ -141,7 +148,9 @@ namespace Server
                 QuestInfoListViewNF.Items.Add(item);
             }
         }
+        #endregion
 
+        #region PlayerItems
         private void UpdatePlayerItems()
         {
             PlayerItemInfoListViewNF.Items.Clear();
@@ -207,7 +216,7 @@ namespace Server
                 }
                 else
                 {
-                    storeItemListItem.SubItems.Add($"Storage II | Slot: [{i -79}]");
+                    storeItemListItem.SubItems.Add($"Storage II | Slot: [{i - 79}]");
                 }
 
                 storeItemListItem.SubItems.Add($"{storeItem.FriendlyName}");
@@ -234,7 +243,9 @@ namespace Server
                 PlayerItemInfoListViewNF.Items.Add(equipItemListItem);
             }
         }
+        #endregion
 
+        #region Buttons
         private void UpdateButton_Click(object sender, EventArgs e)
         {
             if (MessageBox.Show("Are you sure you want to Update?", "Update.", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning) != DialogResult.Yes) return;
@@ -330,9 +341,6 @@ namespace Server
             form.ShowDialog();
         }
 
-
-
-
         private void CurrentIPLabel_Click(object sender, EventArgs e)
         {
             string ipAddress = CurrentIPLabel.Text;
@@ -369,7 +377,9 @@ namespace Server
 
             Character.Player.Connection.SendDisconnect(6);
         }
+        #endregion
 
+        #region PlayerFlagSearch
         private void FlagSearchBox_ValueChanged_1(object sender, EventArgs e)
         {
             int flagIndex = 0;
@@ -404,7 +414,9 @@ namespace Server
                 ResultLabel.ForeColor = Color.Red;
             }
         }
-        
+        #endregion
+
+        #region UpdateTabs
         private void UpdateTabs()
         {
             UpdatePlayerInfo();
@@ -413,7 +425,9 @@ namespace Server
             UpdatePlayerMagics();
             UpdatePlayerQuests();
         }
+        #endregion
 
+        #region Tab Resize
         private void tabControl1_SelectedIndexChanged(object sender, EventArgs e)
         {
             switch (tabControl1.SelectedIndex)
@@ -437,5 +451,6 @@ namespace Server
 
             UpdateTabs();
         }
+        #endregion
     }
 }

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -32,11 +32,9 @@ namespace Server
         #region PlayerInfo
         private void UpdatePlayerInfo()
         {
+            if (Character?.Player == null) return;
 
-            if (Character == null) return;
-            if (Character.Player == null) return;
-
-                IndexTextBox.Text = Character.Index.ToString();
+            IndexTextBox.Text = Character.Index.ToString();
             NameTextBox.Text = Character.Name;
             LevelTextBox.Text = Character.Level.ToString();
             PKPointsTextBox.Text = Character.PKPoints.ToString();
@@ -44,7 +42,7 @@ namespace Server
             GameGoldTextBox.Text = String.Format("{0:n0}", Character.AccountInfo.Credit);
 
 
-            if (Character.Player != null)
+            if (Character?.Player != null)
             {
                 CurrentMapLabel.Text = $"{Character.Player.CurrentMap.Info.Title} {Character.Player.CurrentMap.Info.FileName} {Character.CurrentLocation.X}:{Character.CurrentLocation.Y}";
 
@@ -75,8 +73,7 @@ namespace Server
         {
             ClearPetInfo();
 
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
 
             foreach (MonsterObject Pet in Character.Player.Pets)
             {
@@ -259,8 +256,7 @@ namespace Server
         #region Buttons
         private void UpdateButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
 
             if (MessageBox.Show("Are you sure you want to Update?", "Update.", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning) != DialogResult.Yes) return;
 
@@ -285,8 +281,7 @@ namespace Server
 
         private void SendMessageButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
 
             if (SendMessageTextBox.Text.Length < 1) return;
 
@@ -295,8 +290,7 @@ namespace Server
 
         private void KickButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
 
             Character.Player.Connection.SendDisconnect(4);
             //also update account so player can't log back in for x minutes?
@@ -304,16 +298,14 @@ namespace Server
 
         private void KillButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
 
             Character.Player.Die();
         }
 
         private void KillPetsButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
 
             for (int i = Character.Player.Pets.Count - 1; i >= 0; i--)
                 Character.Player.Pets[i].Die();
@@ -322,16 +314,14 @@ namespace Server
         }
         private void SafeZoneButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
 
             Character.Player.Teleport(SMain.Envir.GetMap(Character.BindMapIndex), Character.BindLocation);
         }
 
         private void ChatBanButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
             if (Character.AccountInfo.AdminAccount) return;
 
             Character.ChatBanned = true;
@@ -359,8 +349,7 @@ namespace Server
 
         private void OpenAccountButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
 
             string accountId = Character.AccountInfo.AccountID;
 
@@ -392,8 +381,7 @@ namespace Server
 
         private void AccountBanButton_Click(object sender, EventArgs e)
         {
-            if (Character == null) return;
-            if (Character.Player == null) return;
+            if (Character?.Player == null) return;
             if (Character.AccountInfo.AdminAccount) return;
 
             Character.AccountInfo.Banned = true;

--- a/Server.MirForms/Account/PlayerInfoForm.cs
+++ b/Server.MirForms/Account/PlayerInfoForm.cs
@@ -32,8 +32,6 @@ namespace Server
         #region PlayerInfo
         private void UpdatePlayerInfo()
         {
-            if (Character?.Player == null) return;
-
             IndexTextBox.Text = Character.Index.ToString();
             NameTextBox.Text = Character.Name;
             LevelTextBox.Text = Character.Level.ToString();

--- a/Server.MirForms/Systems/GuildItemForm.cs
+++ b/Server.MirForms/Systems/GuildItemForm.cs
@@ -20,6 +20,7 @@ namespace Server.Systems
             InitializeComponent();
         }
 
+        #region Delete Button
         private void DeleteButton_Click(object sender, EventArgs e)
         {
             if (MemberListView == null) return;
@@ -38,5 +39,6 @@ namespace Server.Systems
                 break;
             }
         }
+        #endregion
     }
 }


### PR DESCRIPTION
When accessing tabs inside the Player Info Form after the player has logged out, a crash will take place.
This was also the case for updating PlayerInfo.

Code now checks for Player before executing anything.