### PR TITLE
Map fixes

### DIFF
--- a/Client/MirObjects/MapCode.cs
+++ b/Client/MirObjects/MapCode.cs
@@ -304,6 +304,9 @@
                             };
                         offSet++;
 
+                        if (MapCells[x, y].FrontIndex >= 255)
+                            MapCells[x, y].FrontIndex = -1;
+
                         if (MapCells[x, y].Light >= 100 && MapCells[x, y].Light <= 119)
                             MapCells[x, y].FishingCell = true;
                     }

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -11196,6 +11196,9 @@ namespace Client.MirScenes
                     if (x < 0) continue;
                     if (x >= Width) break;
                     int imageIndex = (M2CellInfo[x, y].FrontImage & 0x7FFF) - 1;
+                    if (imageIndex == -1) continue;
+                    int fileIndex = M2CellInfo[x, y].FrontIndex;
+                    if (fileIndex == -1) continue;
                     if (M2CellInfo[x, y].Light <= 0 || M2CellInfo[x, y].Light >= 10) continue;
                     if (M2CellInfo[x, y].Light == 0) continue;
 
@@ -11226,8 +11229,6 @@ namespace Client.MirScenes
                     {
                         lightIntensity = GetBlindLight(lightIntensity);
                     }
-
-                    int fileIndex = M2CellInfo[x, y].FrontIndex;
 
                     p = new Point(
                         (x + OffSetX - MapObject.User.Movement.X) * CellWidth + MapObject.User.OffSetMove.X,

--- a/LibraryEditor/Graphics/WeMadeLibrary.cs
+++ b/LibraryEditor/Graphics/WeMadeLibrary.cs
@@ -96,6 +96,7 @@ namespace LibraryEditor
 
                 if (_nType == 0)
                 {
+                    _fStream.Seek(48, SeekOrigin.Begin);
                     _palette = new int[_bReader.ReadInt32()];
                     _fStream.Seek(4, SeekOrigin.Current);
                     _version = _bReader.ReadInt32();

--- a/Server/MirEnvir/Map.cs
+++ b/Server/MirEnvir/Map.cs
@@ -92,7 +92,7 @@ namespace Server.MirEnvir
                 return 1;
 
             //shanda's 2012 format and one of shandas(wemades) older formats share same header info, only difference is the filesize
-            if ((input[4] == 0x0F) && (input[18] == 0x0D) && (input[19] == 0x0A))
+            if ((input[4] == 0x0F) || (input[4] == 0x03) && (input[18] == 0x0D) && (input[19] == 0x0A))
             {
                 int W = input[0] + (input[1] << 8);
                 int H = input[2] + (input[3] << 8);


### PR DESCRIPTION
Fixes reading from the wrong mir2 object files.
Fixes trying to draw with invalid file or image index.
Fixes server Shanda mir2 map detection.
Fixes reading and converting mir2 16 bit .wil libraries.