### PR TITLE
Fix client exception when receiving buffs before player is valid.

### DIFF
--- a/Server/MirObjects/MapObject.cs
+++ b/Server/MirObjects/MapObject.cs
@@ -347,9 +347,10 @@ namespace Server.MirObjects
 
             OperateTime = Envir.Time + Envir.Random.Next(OperateDelay);
 
-            InSafeZone = CurrentMap != null && CurrentMap.GetSafeZone(CurrentLocation) != null;
             BroadcastInfo();
             BroadcastHealthChange();
+
+            InSafeZone = CurrentMap != null && CurrentMap.GetSafeZone(CurrentLocation) != null;
         }
         public virtual void Despawn()
         {


### PR DESCRIPTION
InSafeZone will call OnSafeZoneChanged, which for players can pause/unpause buffs. The exception occurs because BroadcastInfo was sent after the buff and the player in the client is not valid yet.