### PR TITLE
Fix #828

### DIFF
--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -9287,7 +9287,11 @@ namespace Server.MirObjects
                 ReceiveChat("You have not been invited to a guild.", ChatType.System);
                 return;
             }
-            if (!accept) return;
+            if (!accept)
+            {
+                PendingGuildInvite = null;
+                return;
+            }
             if (!PendingGuildInvite.HasRoom())
             {
                 ReceiveChat(String.Format("{0} is full.", PendingGuildInvite.Name), ChatType.System);


### PR DESCRIPTION
Guild invite was not being set to null if it was refused, subsequent invites would fail.