### PR TITLE
Fix for inverted GS Credit/Gold checkboxes

### DIFF
--- a/Shared/Data/ItemData.cs
+++ b/Shared/Data/ItemData.cs
@@ -820,8 +820,8 @@ public class GameShopItem
         Date = DateTime.FromBinary(reader.ReadInt64());
         if (version > 105)
         {
-            CanBuyGold = reader.ReadBoolean();
             CanBuyCredit = reader.ReadBoolean();
+            CanBuyGold = reader.ReadBoolean();
         }
 
     }


### PR DESCRIPTION
-Fixed GameShopForm issue whereby rebooting the server causes Credit/Gold checkbox values to switch (different read orders when saving/loading DB)