### PR TITLE
SpriteScale (Image Scaling)

### DIFF
--- a/Client/MirControls/MirImageControl.cs
+++ b/Client/MirControls/MirImageControl.cs
@@ -6,6 +6,7 @@ namespace Client.MirControls
     {
         public override Point DisplayLocation { get { return UseOffSet ? base.DisplayLocation.Add(Library.GetOffSet(Index)) : base.DisplayLocation; } }
         public Point DisplayLocationWithoutOffSet { get { return base.DisplayLocation; } }
+        public float SpriteScale { get; set; } = 1f;
 
         #region Auto Size
         private bool _autoSize;
@@ -184,9 +185,13 @@ namespace Client.MirControls
                 }
 
                 if (Blending)
-                    Library.DrawBlend(Index, DisplayLocation, ForeColour, false, BlendingRate);
+                {
+                    Library.DrawBlend(Index, DisplayLocation, ForeColour, false, BlendingRate, SpriteScale);
+                }
                 else
-                    Library.Draw(Index, DisplayLocation, ForeColour, false, Opacity);
+                {
+                    Library.Draw(Index, DisplayLocation, ForeColour, false, Opacity, SpriteScale);
+                }
 
                 if (GrayScale) DXManager.SetGrayscale(oldGray);
             }

--- a/Client/MirGraphics/MLibrary.cs
+++ b/Client/MirGraphics/MLibrary.cs
@@ -665,39 +665,83 @@ namespace Client.MirGraphics
             mi.CleanTime = CMain.Time + Settings.CleanDelay;
         }
 
-        public void Draw(int index, Point point, Color colour, bool offSet, float opacity)
+        public void Draw(int index, Point point, Color colour, bool offSet, float opacity, float scale = 1f)
         {
             if (!CheckImage(index))
                 return;
 
             MImage mi = _images[index];
 
+            if (scale <= 0f)
+                scale = 1f;
+
             if (offSet) point.Offset(mi.X, mi.Y);
 
-            if (point.X >= Settings.ScreenWidth || point.Y >= Settings.ScreenHeight || point.X + mi.Width < 0 || point.Y + mi.Height < 0)
+            float scaledWidth = mi.Width * scale;
+            float scaledHeight = mi.Height * scale;
+
+            if (point.X >= Settings.ScreenWidth || point.Y >= Settings.ScreenHeight || point.X + scaledWidth < 0f || point.Y + scaledHeight < 0f)
                 return;
 
-            DXManager.DrawOpaque(mi.Image, new Rectangle(0, 0, mi.Width, mi.Height), new Vector3((float)point.X, (float)point.Y, 0.0F), colour, opacity); 
+            Rectangle drawRect = new Rectangle(0, 0, mi.Width, mi.Height);
+            bool scaled = scale < 0.999f || scale > 1.001f;
+
+            if (scaled)
+            {
+                Matrix matrix = Matrix.Scaling(scale, scale, 0);
+                DXManager.Sprite.Transform = matrix;
+
+                Vector3 drawPoint = new Vector3(point.X / scale, point.Y / scale, 0.0F);
+                DXManager.DrawOpaque(mi.Image, drawRect, drawPoint, colour, opacity);
+
+                DXManager.Sprite.Transform = Matrix.Identity;
+            }
+            else
+            {
+                DXManager.DrawOpaque(mi.Image, drawRect, new Vector3((float)point.X, (float)point.Y, 0.0F), colour, opacity);
+            }
 
             mi.CleanTime = CMain.Time + Settings.CleanDelay;
         }
 
-        public void DrawBlend(int index, Point point, Color colour, bool offSet = false, float rate = 1)
+        public void DrawBlend(int index, Point point, Color colour, bool offSet = false, float rate = 1, float scale = 1f)
         {
             if (!CheckImage(index))
                 return;
 
             MImage mi = _images[index];
 
+            if (scale <= 0f)
+                scale = 1f;
+
             if (offSet) point.Offset(mi.X, mi.Y);
 
-            if (point.X >= Settings.ScreenWidth || point.Y >= Settings.ScreenHeight || point.X + mi.Width < 0 || point.Y + mi.Height < 0)
+            float scaledWidth = mi.Width * scale;
+            float scaledHeight = mi.Height * scale;
+
+            if (point.X >= Settings.ScreenWidth || point.Y >= Settings.ScreenHeight || point.X + scaledWidth < 0f || point.Y + scaledHeight < 0f)
                 return;
 
             bool oldBlend = DXManager.Blending;
             DXManager.SetBlend(true, rate);
 
-            DXManager.Draw(mi.Image, new Rectangle(0, 0, mi.Width, mi.Height), new Vector3((float)point.X, (float)point.Y, 0.0F), colour);
+            Rectangle drawRect = new Rectangle(0, 0, mi.Width, mi.Height);
+            bool scaled = scale < 0.999f || scale > 1.001f;
+
+            if (scaled)
+            {
+                Matrix matrix = Matrix.Scaling(scale, scale, 0);
+                DXManager.Sprite.Transform = matrix;
+
+                Vector3 drawPoint = new Vector3(point.X / scale, point.Y / scale, 0.0F);
+                DXManager.Draw(mi.Image, drawRect, drawPoint, colour);
+
+                DXManager.Sprite.Transform = Matrix.Identity;
+            }
+            else
+            {
+                DXManager.Draw(mi.Image, drawRect, new Vector3((float)point.X, (float)point.Y, 0.0F), colour);
+            }
 
             DXManager.SetBlend(oldBlend);
             mi.CleanTime = CMain.Time + Settings.CleanDelay;


### PR DESCRIPTION
- added sprite scaling support to `MirImageControl` 
- extend `MLibrary.Draw`/`DrawBlend` to accept an optional `scale` parameter, clamp invalid values, adjust culling bounds to the scaled dimensions, and apply/unapply a `Matrix.Scaling` transform so scaled sprites render correctly while preserving the existing default behaviour when scale == 1

SpriteScale = 1.0f = normal. 
<img width="1024" height="768" alt="Image 11" src="https://github.com/user-attachments/assets/acbfeb8a-b0e9-4552-8b42-baa6b057ffef" />
<img width="1024" height="768" alt="Image 9" src="https://github.com/user-attachments/assets/b1e140ea-1ebe-4cc2-bd40-e72286a86af3" />
<img width="1024" height="768" alt="Image 10" src="https://github.com/user-attachments/assets/d378a0db-56ce-4da6-ad45-1f869681cd09" />
3 test screenshots. 0.5 1.5, 1.0 
