### PR TITLE
Fix : correct NameLabel color update behavior

### DIFF
--- a/Client/MirObjects/HeroObject.cs
+++ b/Client/MirObjects/HeroObject.cs
@@ -48,13 +48,16 @@ namespace Client.MirObjects
 
             for (int i = 0; i < LabelList.Count; i++)
             {
-                if (LabelList[i].Text != ownerText || LabelList[i].ForeColour != NameColour) continue;
+                if (LabelList[i].Text != ownerText) continue;
                 OwnerLabel = LabelList[i];
                 break;
             }
 
-            if (OwnerLabel != null && !OwnerLabel.IsDisposed) return;
-
+            if (OwnerLabel != null && !OwnerLabel.IsDisposed)
+            {
+                if (OwnerLabel.ForeColour != NameColour) OwnerLabel.ForeColour = NameColour;
+                return;
+            }
             OwnerLabel = new MirLabel
             {
                 AutoSize = true,

--- a/Client/MirObjects/ItemObject.cs
+++ b/Client/MirObjects/ItemObject.cs
@@ -126,12 +126,19 @@ namespace Client.MirObjects
 
             for (int i = 0; i < LabelList.Count; i++)
             {
-                if (LabelList[i].Text != Name || LabelList[i].Border != border || LabelList[i].BackColour != backColour || LabelList[i].ForeColour != NameColour || LabelList[i].OutLine != outline) continue;
+                if (LabelList[i].Text != Name) continue;
                 NameLabel = LabelList[i];
                 break;
             }
 
-            if (NameLabel != null && !NameLabel.IsDisposed) return;
+            if (NameLabel != null && !NameLabel.IsDisposed)
+            {
+                if (NameLabel.Border != border) NameLabel.Border = border;
+                if (NameLabel.BackColour != backColour) NameLabel.BackColour = backColour;
+                if (NameLabel.ForeColour != NameColour) NameLabel.ForeColour = NameColour;
+                if (NameLabel.OutLine != outline) NameLabel.OutLine = outline;
+                return;
+            }
 
             NameLabel = new MirControls.MirLabel
             {

--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -73,11 +73,15 @@ namespace Client.MirObjects
             NameColour = info.NameColour;
             BaseImage = info.Image;
 
-            OldNameColor = NameColour;
+           
 
             CurrentLocation = info.Location;
             MapLocation = info.Location;
-            if (!update) GameScene.Scene.MapControl.AddObject(this);
+            if (!update)
+            {
+                OldNameColor = NameColour;
+                GameScene.Scene.MapControl.AddObject(this);
+            }
 
             Effect = info.Effect;
             AI = info.AI;
@@ -5638,7 +5642,15 @@ namespace Client.MirObjects
                 break;
             }
 
-            if (TempLabel != null && !TempLabel.IsDisposed && NameColour == OldNameColor) return;
+            if (TempLabel != null && !TempLabel.IsDisposed)
+            {
+                if (NameColour != OldNameColor)
+                {
+                    TempLabel.ForeColour = NameColour;
+                    OldNameColor = NameColour;
+                }
+                return;
+            }
 
             OldNameColor = NameColour;
 

--- a/Client/MirObjects/NPCObject.cs
+++ b/Client/MirObjects/NPCObject.cs
@@ -349,12 +349,19 @@ namespace Client.MirObjects
             var setForeColour = (wordOrder == 0 ? NameColour : Color.White);
             for (int i = 0; i < LabelList.Count; i++)
             {
-                if (LabelList[i].Text != word || LabelList[i].ForeColour != setForeColour) continue;
+                if (LabelList[i].Text != word) continue;
                 TempLabel = LabelList[i];
                 break;
             }
 
-            if (TempLabel != null && !TempLabel.IsDisposed) return;
+            if (TempLabel != null && !TempLabel.IsDisposed)
+            {
+                if (TempLabel.ForeColour != setForeColour)
+                {
+                    TempLabel.ForeColour = setForeColour;
+                }
+                return;
+            }
 
             TempLabel = new MirLabel
             {

--- a/Client/MirObjects/PlayerObject.cs
+++ b/Client/MirObjects/PlayerObject.cs
@@ -5196,12 +5196,19 @@ namespace Client.MirObjects
         {
             for (int i = 0; i < LabelList.Count; i++)
             {
-                if (LabelList[i].Text != Name || LabelList[i].ForeColour != NameColour) continue;
+                if (LabelList[i].Text != Name) continue;
                 NameLabel = LabelList[i];
                 break;
             }
 
-            if (NameLabel != null && !NameLabel.IsDisposed) return;
+            if (NameLabel != null && !NameLabel.IsDisposed)
+            {
+                if (NameLabel.ForeColour != NameColour)
+                {
+                    NameLabel.ForeColour = NameColour;
+                }
+                return;
+            }
 
             NameLabel = new MirLabel
             {
@@ -5223,12 +5230,16 @@ namespace Client.MirObjects
 
             for (int i = 0; i < LabelList.Count; i++)
             {
-                if (LabelList[i].Text != GuildName || LabelList[i].ForeColour != NameColour) continue;
+                if (LabelList[i].Text != GuildName) continue;
                 GuildLabel = LabelList[i];
                 break;
             }
 
-            if (GuildLabel != null && !GuildLabel.IsDisposed) return;
+            if (GuildLabel != null && !GuildLabel.IsDisposed)
+            {
+                if (GuildLabel.ForeColour != NameColour) GuildLabel.ForeColour = NameColour;
+                return;
+            }
 
             GuildLabel = new MirLabel
             {


### PR DESCRIPTION
When checking `LabelList[i].ForeColour != NameColour`, the code incorrectly created a new `MirLabel`, causing Taoist/Wizard pets to fail to update their name color after leveling up.

When an existing NameLabel with the same name is found, its properties should be updated instead of creating a new instance.