### PR TITLE
Purple Hero Name #791

### DIFF
--- a/Server/MirObjects/HeroObject.cs
+++ b/Server/MirObjects/HeroObject.cs
@@ -252,6 +252,21 @@ namespace Server.MirObjects
 
             BroadcastHealthChange();
             BroadcastManaChange();
+            BroadcastColourChange();
+        }
+
+        public override void Add(HumanObject player)
+        {
+            base.Add(player);
+
+            if (player is PlayerObject viewer)
+            {
+                viewer.Enqueue(new S.ObjectColourChanged
+                {
+                    ObjectID = ObjectID,
+                    NameColour = viewer.GetNameColour(this)
+                });
+            }
         }
 
         protected virtual void GetItemInfo()


### PR DESCRIPTION
Hero name colour stays white after map changes:

- call `BroadcastColourChange` when heroes spawn so nearby clients get an immediate refresh alongside health/mana
- override `HeroObject.Add` to send an `ObjectColourChanged` packet tailored to the joining viewer’s `GetNameColour` result
- prevents the purple fallback described in Purple Hero Name #791

