### PR TITLE
Unify GetInfo; add MasterObjectId/Rarity; client-side rarity display

### DIFF
--- a/Client/Localization/Chinese.json
+++ b/Client/Localization/Chinese.json
@@ -1194,6 +1194,10 @@
     "AwakeType_SC": "道术",
     "AwakeType_AC": "物防",
     "AwakeType_MAC": "魔防",
-    "AwakeType_HPMP": "生命值法力值"
+    "AwakeType_HPMP": "生命值法力值",
+    "MonsterType_Normal": "普通",
+    "MonsterType_Uncommon": "非凡",
+    "MonsterType_Rare": "稀有",
+    "MonsterType_Elite": "精英"
   }
 }

--- a/Client/Localization/English.json
+++ b/Client/Localization/English.json
@@ -1197,6 +1197,10 @@
     "AwakeType_SC": "SC",
     "AwakeType_AC": "AC",
     "AwakeType_MAC": "MAC",
-    "AwakeType_HPMP": "HPMP"
+    "AwakeType_HPMP": "HPMP",
+    "MonsterType_Normal": "Normal",
+    "MonsterType_Uncommon": "Uncommon",
+    "MonsterType_Rare": "Rare",
+    "MonsterType_Elite": "Elite"
   }
 }

--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -65,6 +65,10 @@ namespace Client.MirObjects
 
         public SpellEffect CurrentEffect;
 
+        public uint MasterObjectId;
+
+        public MonsterType Rarity;
+
         public MonsterObject(uint objectID) : base(objectID) { }
 
         public void Load(S.ObjectMonster info, bool update = false)
@@ -91,6 +95,15 @@ namespace Client.MirObjects
             ShockTime = CMain.Time + info.ShockTime;
             BindingShotCenter = info.BindingShotCenter;
 
+            MasterObjectId = info.MasterObjectId;
+            Rarity = info.Rarity;
+
+            if (MasterObjectId == 0 && Rarity != MonsterType.Normal)
+            {
+                //Moving the rarity tag processing from the server to the client allows for more complex tag displays in the future, such as adding special markers on monster health bars.
+                //Add localization for rarity text
+                Name = $"{Rarity.ToLocalizedString()}_{Name}";
+            }
             Buffs = info.Buffs;
 
             if (Stage != info.ExtraByte)
@@ -3201,7 +3214,7 @@ namespace Client.MirObjects
                                             ob = MapControl.GetObject(TargetID);
                                             if (ob != null)
                                             {
-                                                ob.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.MudZombie], 304, 7, 700, ob) { Blend = false } );
+                                                ob.Effects.Add(new Effect(Libraries.Monsters[(ushort)Monster.MudZombie], 304, 7, 700, ob) { Blend = false });
                                             }
                                             break;
                                         case Monster.DarkSpirit:
@@ -3952,7 +3965,7 @@ namespace Client.MirObjects
         }
         public void PlayStruckSound()
         {
-            switch(BaseImage)
+            switch (BaseImage)
             {
                 case Monster.EvilMir:
                     SoundManager.PlaySound(SoundList.StruckEvilMir);
@@ -5589,33 +5602,33 @@ namespace Client.MirObjects
                 base.DrawName();
                 return;
             }
-                
+
             string[] splitName = Name.Split('_');
 
             //IntelligentCreature
             int yOffset = 0;
-                switch (BaseImage)
-                {
-                    case Monster.Chick:
-                        yOffset = -10;
-                        break;
-                    case Monster.BabyPig:
-                    case Monster.Kitten:
-                    case Monster.BabySkeleton:
-                    case Monster.Baekdon:
-                    case Monster.Wimaen:
-                    case Monster.BlackKitten:
-                    case Monster.BabyDragon:
-                    case Monster.OlympicFlame:
-                    case Monster.BabySnowMan:
-                    case Monster.Frog:
-                    case Monster.BabyMonkey:
-                    case Monster.AngryBird:
-                    case Monster.Foxey:
-                    case Monster.MedicalRat:
-                        yOffset = -20;
-                        break;
-                }
+            switch (BaseImage)
+            {
+                case Monster.Chick:
+                    yOffset = -10;
+                    break;
+                case Monster.BabyPig:
+                case Monster.Kitten:
+                case Monster.BabySkeleton:
+                case Monster.Baekdon:
+                case Monster.Wimaen:
+                case Monster.BlackKitten:
+                case Monster.BabyDragon:
+                case Monster.OlympicFlame:
+                case Monster.BabySnowMan:
+                case Monster.Frog:
+                case Monster.BabyMonkey:
+                case Monster.AngryBird:
+                case Monster.Foxey:
+                case Monster.MedicalRat:
+                    yOffset = -20;
+                    break;
+            }
 
             for (int s = 0; s < splitName.Count(); s++)
             {

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -11766,7 +11766,7 @@ namespace Client.MirScenes
                 case Spell.PetEnhancer:
                     if (actor.NextMagicObject != null)
                     {
-                        if (!actor.NextMagicObject.Dead && actor.NextMagicObject.Race != ObjectType.Item && actor.NextMagicObject.Race != ObjectType.Merchant)
+                        if (!actor.NextMagicObject.Dead && actor.NextMagicObject.Race != ObjectType.Item && actor.NextMagicObject.Race != ObjectType.Merchant && !(actor.NextMagicObject is MonsterObject monster && monster.MasterObjectId == 0))
                             target = actor.NextMagicObject;
                     }
 

--- a/Server/MirObjects/IntelligentCreatureObject.cs
+++ b/Server/MirObjects/IntelligentCreatureObject.cs
@@ -851,24 +851,9 @@ namespace Server.MirObjects
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet=(S.ObjectMonster)base.GetInfo();
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/MonsterObject.cs
+++ b/Server/MirObjects/MonsterObject.cs
@@ -509,12 +509,7 @@ namespace Server.MirObjects
         {
             get
             {
-                string baseName = Master == null ? Info.GameName : string.Format("{0}({1})", Info.GameName, Master.Name);
-
-                if (Master == null && MonsterType != MonsterType.Normal)
-                    return string.Format("{0}_{1}", MonsterType, baseName);
-
-                return baseName;
+                return Master == null ? Info.GameName : string.Format("{0}({1})", Info.GameName, Master.Name);
             }
             set { throw new NotSupportedException(); }
         }
@@ -2878,7 +2873,9 @@ namespace Server.MirObjects
                 Hidden = Hidden,
                 ShockTime = (ShockTime > 0 ? ShockTime - Envir.Time : 0),
                 BindingShotCenter = BindingShotCenter,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
+                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList(),
+                MasterObjectId = Master?.ObjectID ?? 0,
+                Rarity= MonsterType
             };
         }
 

--- a/Server/MirObjects/Monsters/BoneFamiliar.cs
+++ b/Server/MirObjects/Monsters/BoneFamiliar.cs
@@ -21,24 +21,9 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/CharmedSnake.cs
+++ b/Server/MirObjects/Monsters/CharmedSnake.cs
@@ -46,11 +46,11 @@ namespace Server.MirObjects.Monsters
             }
         }
 
-       // protected override void ProcessAI()
-       // {
-           // ProcessSearch();
-           // ProcessRoam();
-           // ProcessTarget();
+        // protected override void ProcessAI()
+        // {
+        // ProcessSearch();
+        // ProcessRoam();
+        // ProcessTarget();
         //}
 
         protected override void ProcessAI()
@@ -243,24 +243,10 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Monster.CharmedSnake,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Image = Monster.CharmedSnake;
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/FrostTiger.cs
+++ b/Server/MirObjects/Monsters/FrostTiger.cs
@@ -163,24 +163,9 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Sitting,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Extra = Sitting;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/GreatFoxSpirit.cs
+++ b/Server/MirObjects/Monsters/GreatFoxSpirit.cs
@@ -178,24 +178,9 @@ namespace Server.MirObjects.Monsters
         
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                ExtraByte = _stage,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.ExtraByte = _stage;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/HellKnight.cs
+++ b/Server/MirObjects/Monsters/HellKnight.cs
@@ -32,24 +32,9 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/HellLord.cs
+++ b/Server/MirObjects/Monsters/HellLord.cs
@@ -239,24 +239,9 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                ExtraByte = _stage,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.ExtraByte = _stage;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/HolyDeva.cs
+++ b/Server/MirObjects/Monsters/HolyDeva.cs
@@ -105,24 +105,10 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Monster.HolyDeva,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Image = Monster.HolyDeva;
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/HornedMage.cs
+++ b/Server/MirObjects/Monsters/HornedMage.cs
@@ -1,5 +1,5 @@
 using System.Drawing;
-﻿using Server.MirDatabase;
+using Server.MirDatabase;
 using Server.MirEnvir;
 using S = ServerPackets;
 
@@ -108,28 +108,6 @@ namespace Server.MirObjects.Monsters
                 targets[i].Attacked(this, damage, defence);
             }
             return;
-        }
-
-
-        public override Packet GetInfo()
-        {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList(),
-            };
         }
     }
 }

--- a/Server/MirObjects/Monsters/PowerBead.cs
+++ b/Server/MirObjects/Monsters/PowerBead.cs
@@ -144,24 +144,9 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Extra = Summoned;
+            return packet;
         }
 
         public static bool SpawnRandom(MonsterObject owner, Point spawn)

--- a/Server/MirObjects/Monsters/Shinsu.cs
+++ b/Server/MirObjects/Monsters/Shinsu.cs
@@ -90,24 +90,10 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Mode ? Monster.Shinsu1 : Monster.Shinsu,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Image = Mode ? Monster.Shinsu1 : Monster.Shinsu;
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/SnakeTotem.cs
+++ b/Server/MirObjects/Monsters/SnakeTotem.cs
@@ -174,24 +174,10 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Monster.SnakeTotem,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Image = Monster.SnakeTotem;
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/SpittingToad.cs
+++ b/Server/MirObjects/Monsters/SpittingToad.cs
@@ -132,24 +132,10 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Monster.SpittingToad,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Image = Monster.SpittingToad;
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/StoneTrap.cs
+++ b/Server/MirObjects/Monsters/StoneTrap.cs
@@ -131,24 +131,10 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Monster.StoningSpider,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Image = Monster.StoningSpider;
+            packet.Extra = Summoned;
+            return packet;
         }
     }
 }

--- a/Server/MirObjects/Monsters/TreeQueen.cs
+++ b/Server/MirObjects/Monsters/TreeQueen.cs
@@ -285,26 +285,6 @@ namespace Server.MirObjects.Monsters
             }
         }
 
-        public override Packet GetInfo()
-        {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
-        }
 
         public override void Spawned()
         {

--- a/Server/MirObjects/Monsters/VampireSpider.cs
+++ b/Server/MirObjects/Monsters/VampireSpider.cs
@@ -192,24 +192,10 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Monster.VampireSpider,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Summoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Image = Monster.VampireSpider;
+            packet.Extra = Summoned;
+            return packet;
         }
 
     }

--- a/Server/MirObjects/Monsters/ZumaMonster.cs
+++ b/Server/MirObjects/Monsters/ZumaMonster.cs
@@ -179,24 +179,9 @@ namespace Server.MirObjects.Monsters
 
         public override Packet GetInfo()
         {
-            return new S.ObjectMonster
-            {
-                ObjectID = ObjectID,
-                Name = Name,
-                NameColour = NameColour,
-                Location = CurrentLocation,
-                Image = Info.Image,
-                Direction = Direction,
-                Effect = Info.Effect,
-                AI = Info.AI,
-                Light = Info.Light,
-                Dead = Dead,
-                Skeleton = Harvested,
-                Poison = CurrentPoison,
-                Hidden = Hidden,
-                Extra = Stoned,
-                Buffs = Buffs.Where(d => d.Info.Visible).Select(e => e.Type).ToList()
-            };
+            var packet = (S.ObjectMonster)base.GetInfo();
+            packet.Extra = Stoned;
+            return packet;
         }
     }
 }

--- a/Shared/Language.cs
+++ b/Shared/Language.cs
@@ -4008,7 +4008,8 @@ public static class GameLanguage
         typeof(Stat),
         typeof(BuffType),
         typeof(PoisonType),
-        typeof(AwakeType)
+        typeof(AwakeType),
+        typeof(MonsterType)
     ];
 
     static GameLanguage()

--- a/Shared/ServerPackets.cs
+++ b/Shared/ServerPackets.cs
@@ -2230,6 +2230,8 @@ namespace ServerPackets
         public byte ExtraByte;
         public long ShockTime;
         public bool BindingShotCenter;
+        public uint MasterObjectId;
+        public MonsterType Rarity;
 
         public List<BuffType> Buffs = new List<BuffType>();
 
@@ -2252,6 +2254,8 @@ namespace ServerPackets
             BindingShotCenter = reader.ReadBoolean();
             Extra = reader.ReadBoolean();
             ExtraByte = reader.ReadByte();
+            MasterObjectId= reader.ReadUInt32();
+            Rarity= (MonsterType)reader.ReadByte();
 
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)
@@ -2280,6 +2284,8 @@ namespace ServerPackets
             writer.Write(BindingShotCenter);
             writer.Write(Extra);
             writer.Write((byte)ExtraByte);
+            writer.Write(MasterObjectId);
+            writer.Write((byte)Rarity);
 
             writer.Write(Buffs.Count);
             for (int i = 0; i < Buffs.Count; i++)


### PR DESCRIPTION
1. Standardized GetInfo() across all MonsterObject subclasses to call base.GetInfo() first, then let subclasses modify specific fields as needed. This preserves code reuse while allowing subclass-specific behavior, reducing duplication and maintenance cost.
2. Added two fields to S.ObjectMonster:
   - MasterObjectId: distinguishes wild monsters from summoned minions (summons carry the summoner's ID).
   - Rarity: an enum representing monster rarity for display and logic.
3. Shifted control of rarity display from server to client. The client is better suited for visual presentation (e.g., glow effects, star symbols, different healthbar frames). Initially we display rarity as text in the monster name; richer visuals can be implemented on the client without server changes.
4. Use MasterObjectId to differentiate wild monsters and summons, and adjust targeting logic: when a beneficial single-target spell is cast on a wild monster, automatically retarget it to the caster (to avoid affecting summons or other players' pets).

Benefits:
- Improves code reuse and maintainability, reduces duplicate implementations.
- Provides clear ownership and rarity fields for monsters, enabling separation of client visuals and server logic.
- Prepares for enhanced client-side visuals without altering server behavior.