### PR TITLE
#1078 TextBox masking in window mode.

### DIFF
--- a/Client/MirControls/MirTextBox.cs
+++ b/Client/MirControls/MirTextBox.cs
@@ -78,6 +78,31 @@ namespace Client.MirControls
                 TextBox.Location = DisplayLocation;
                 _textBoxOffscreen = false;
             }
+
+            UpdateMouseMoveHook(!_textBoxOffscreen);
+        }
+
+        private void UpdateMouseMoveHook(bool enabled)
+        {
+            if (TextBox == null || TextBox.IsDisposed)
+                return;
+
+            if (enabled)
+            {
+                if (_mouseMoveHooked)
+                    return;
+
+                TextBox.MouseMove += CMain.CMain_MouseMove;
+                _mouseMoveHooked = true;
+            }
+            else
+            {
+                if (!_mouseMoveHooked)
+                    return;
+
+                TextBox.MouseMove -= CMain.CMain_MouseMove;
+                _mouseMoveHooked = false;
+            }
         }
 
         #endregion
@@ -177,6 +202,7 @@ namespace Client.MirControls
         public readonly TextBox TextBox;
         private Pen CaretPen;
         private bool _textBoxOffscreen;
+        private bool _mouseMoveHooked;
 
         private static readonly Point HiddenTextBoxLocation = new Point(-5000, -5000);
 
@@ -376,7 +402,6 @@ namespace Client.MirControls
             TextBox.MouseWheel += TextBox_NeedRedraw;
 
             Shown += MirTextBox_Shown;
-            TextBox.MouseMove += CMain.CMain_MouseMove;
 
             UpdateTextBoxHostLocation(true);
         }
@@ -607,6 +632,8 @@ namespace Client.MirControls
             base.Dispose(disposing);
 
             if (!disposing) return;
+
+            UpdateMouseMoveHook(false);
 
             if (!TextBox.IsDisposed)
                 TextBox.Dispose();


### PR DESCRIPTION
- `UpdateTextBoxHostLocation` now centralizes where the WinForms input control lives. In fullscreen it sits where it always was; in windowed mode it’s moved to `HiddenTextBoxLocation` so it never paints over Mir UIs.
- Mouse input paths (`OnMouseDown/Move/Up/DoubleClick/Wheel`) detect when the control is hidden and replay the corresponding Windows messages via `SendMessage`, using `CMain.MPoint` to compute the caret position. Keyboard input still flows through the real `TextBox`, so all selection/editing behavior is preserved without rewriting it manually.
- Texture creation is still triggered everywhere (windowed + fullscreen), so the Mir-themed mask/caret drawn from `TextBox.DrawToBitmap` now matches in both modes.
<img width="1024" height="768" alt="2image" src="https://github.com/user-attachments/assets/771d23ac-5d00-40e0-bbaa-947c343da151" />
<img width="1198" height="826" alt="1image" src="https://github.com/user-attachments/assets/c9be39ea-0fc8-4903-9d27-2e42433c4fbd" />
![123](https://github.com/user-attachments/assets/e88efbe5-7a2b-4235-8758-5f558190c037)
<img width="1600" height="834" alt="123" src="https://github.com/user-attachments/assets/b8ed389b-e423-4441-b687-b71647581065" />



@Suprcode not sure whether this is the correct direction which AI provided. 
