### PR TITLE
Fishing Rod / Mount Socket information. #966

### DIFF
--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -8472,7 +8472,7 @@ namespace Client.MirScenes
 
             ItemLabel.Size = new Size(ItemLabel.Size.Width, ItemLabel.Size.Height + 4);
 
-            // Fishing rods and mounts should not render socket details (Issue #966)
+            // Fishing rods and mounts should not render socket details 
             if (realItem.IsFishingRod || realItem.Type == ItemType.Mount)
             {
                 ItemLabel.Size = new Size(ItemLabel.Size.Width, ItemLabel.Size.Height - 4);


### PR DESCRIPTION
Hide socket tooltip rows for fishing rods and mounts so their hover info no longer mentions sockets or the socket dialog tip
<img width="1024" height="768" alt="Image 7" src="https://github.com/user-attachments/assets/33677e7f-7207-462e-9e83-f2962df94e23" />
<img width="1024" height="768" alt="Image 8" src="https://github.com/user-attachments/assets/43128d61-102e-417e-9bbb-3c2b0d3f3246" />
