### PR TITLE
#755 Hero Buffs

### DIFF
--- a/Client/MirScenes/Dialogs/BuffDialog.cs
+++ b/Client/MirScenes/Dialogs/BuffDialog.cs
@@ -29,7 +29,7 @@ namespace Client.MirScenes.Dialogs
         {
             Index = 20;
             Library = Libraries.Prguse2;
-            Movable = false;
+            Movable = true;
             Size = new Size(44, 34);
             Location = new Point(Settings.ScreenWidth - 170, 0);
             Sort = true;
@@ -214,7 +214,7 @@ namespace Client.MirScenes.Dialogs
         {
             _buffCount = _buffList.Count;
 
-            var baseImage = 20;
+            var baseImage = (Index >= 40 && Index <= 53) ? 40 : 20;
             var heightOffset = Location.Y;
 
             //foreach (var dialog in GameScene.Scene.BuffDialogs)
@@ -255,7 +255,7 @@ namespace Client.MirScenes.Dialogs
             {
                 var oldWidth = Size.Width;
 
-                Index = 20;
+                Index = baseImage;
             
                 var newX = Location.X - Size.Width + oldWidth;
                 var newY = heightOffset;
@@ -560,7 +560,7 @@ namespace Client.MirScenes.Dialogs
         {
             Index = 40;
             Library = Libraries.Prguse2;
-            Movable = false;
+            Movable = true;
             Size = new Size(44, 34);
             Location = new Point(Settings.ScreenWidth - 170, 0);
             Sort = true;
@@ -836,7 +836,7 @@ namespace Client.MirScenes.Dialogs
         {
             _buffCount = _buffList.Count;
 
-            var baseImage = 20;
+            var baseImage = 40;
             var heightOffset = 36;
 
             if (_buffCount > 0 && Settings.ExpandedBuffWindow)
@@ -867,7 +867,7 @@ namespace Client.MirScenes.Dialogs
             {
                 var oldWidth = Size.Width;
 
-                Index = 20;
+                Index = 40;
 
                 var newX = Location.X - Size.Width + oldWidth;
                 var newY = heightOffset;

--- a/Client/MirScenes/Dialogs/BuffDialog.cs
+++ b/Client/MirScenes/Dialogs/BuffDialog.cs
@@ -1,4 +1,4 @@
-﻿using Client.MirControls;
+using Client.MirControls;
 using Client.MirGraphics;
 using Client.MirSounds;
 
@@ -7,6 +7,7 @@ namespace Client.MirScenes.Dialogs
     public class BuffDialog : MirImageControl
     {
         public List<ClientBuff> Buffs = new List<ClientBuff>();
+        public int BaseImageIndex { get; set; } = 20;
 
         protected MirButton _expandCollapseButton;
         protected MirLabel _buffCountLabel;
@@ -214,7 +215,7 @@ namespace Client.MirScenes.Dialogs
         {
             _buffCount = _buffList.Count;
 
-            var baseImage = (Index >= 40 && Index <= 53) ? 40 : 20;
+            var baseImage = BaseImageIndex;
             var heightOffset = Location.Y;
 
             //foreach (var dialog in GameScene.Scene.BuffDialogs)

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -5186,6 +5186,8 @@ namespace Client.MirScenes
 
             if (Hero != null && buff.ObjectID == Hero.ObjectID)
             {
+                if (HeroBuffsDialog.Index < 40 || HeroBuffsDialog.Index > 53) HeroBuffsDialog.Index = 40;
+
                 for (int i = 0; i < HeroBuffsDialog.Buffs.Count; i++)
                 {
                     if (HeroBuffsDialog.Buffs[i].Type != buff.Type) continue;
@@ -5237,6 +5239,8 @@ namespace Client.MirScenes
 
             if (Hero != null && Hero.ObjectID == p.ObjectID)
             {
+                if (HeroBuffsDialog.Index < 40 || HeroBuffsDialog.Index > 53) HeroBuffsDialog.Index = 40;
+
                 for (int i = 0; i < HeroBuffsDialog.Buffs.Count; i++)
                 {
                     if (HeroBuffsDialog.Buffs[i].Type != p.Type) continue;
@@ -5293,6 +5297,8 @@ namespace Client.MirScenes
 
             if (Hero != null && Hero.ObjectID == p.ObjectID)
             {
+                if (HeroBuffsDialog.Index < 40 || HeroBuffsDialog.Index > 53) HeroBuffsDialog.Index = 40;
+
                 for (int i = 0; i < HeroBuffsDialog.Buffs.Count; i++)
                 {
                     if (HeroBuffsDialog.Buffs[i].Type != p.Type) continue;
@@ -6161,6 +6167,7 @@ namespace Client.MirScenes
                 GetExpandedParameter = () => { return Settings.ExpandedHeroBuffWindow; },
                 SetExpandedParameter = (value) => { Settings.ExpandedHeroBuffWindow = value; }
             };
+            HeroBuffsDialog.Index = 40;
             MainDialog.HeroInfoPanel.Update();
 
             Hero.RefreshStats();

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -5186,8 +5186,6 @@ namespace Client.MirScenes
 
             if (Hero != null && buff.ObjectID == Hero.ObjectID)
             {
-                if (HeroBuffsDialog.Index < 40 || HeroBuffsDialog.Index > 53) HeroBuffsDialog.Index = 40;
-
                 for (int i = 0; i < HeroBuffsDialog.Buffs.Count; i++)
                 {
                     if (HeroBuffsDialog.Buffs[i].Type != buff.Type) continue;
@@ -5239,8 +5237,6 @@ namespace Client.MirScenes
 
             if (Hero != null && Hero.ObjectID == p.ObjectID)
             {
-                if (HeroBuffsDialog.Index < 40 || HeroBuffsDialog.Index > 53) HeroBuffsDialog.Index = 40;
-
                 for (int i = 0; i < HeroBuffsDialog.Buffs.Count; i++)
                 {
                     if (HeroBuffsDialog.Buffs[i].Type != p.Type) continue;
@@ -5297,8 +5293,6 @@ namespace Client.MirScenes
 
             if (Hero != null && Hero.ObjectID == p.ObjectID)
             {
-                if (HeroBuffsDialog.Index < 40 || HeroBuffsDialog.Index > 53) HeroBuffsDialog.Index = 40;
-
                 for (int i = 0; i < HeroBuffsDialog.Buffs.Count; i++)
                 {
                     if (HeroBuffsDialog.Buffs[i].Type != p.Type) continue;
@@ -6164,10 +6158,10 @@ namespace Client.MirScenes
                 Parent = this,
                 Visible = true,
                 Location = new Point(Settings.ScreenWidth - 170, 80),
+                BaseImageIndex = 40,
                 GetExpandedParameter = () => { return Settings.ExpandedHeroBuffWindow; },
                 SetExpandedParameter = (value) => { Settings.ExpandedHeroBuffWindow = value; }
             };
-            HeroBuffsDialog.Index = 40;
             MainDialog.HeroInfoPanel.Update();
 
             Hero.RefreshStats();

--- a/Server/MirDatabase/HeroInfo.cs
+++ b/Server/MirDatabase/HeroInfo.cs
@@ -79,6 +79,17 @@ namespace Server.MirDatabase
                 magic.CastTime = int.MinValue;
                 Magics.Add(magic);
             }  
+
+            // Buff persistence (matches player CharacterInfo.Buffs)
+            if (version > 116)
+            {
+                count = reader.ReadInt32();
+                for (int i = 0; i < count; i++)
+                {
+                    Buff buff = new Buff(reader, version, customVersion);
+                    Buffs.Add(buff);
+                }
+            }
             
             if (version > 99)
             {
@@ -135,6 +146,13 @@ namespace Server.MirDatabase
             for (int i = 0; i < Magics.Count; i++)
             {
                 Magics[i].Save(writer);
+            }
+
+            // Buff persistence (matches player CharacterInfo.Buffs)
+            writer.Write(Buffs.Count);
+            for (int i = 0; i < Buffs.Count; i++)
+            {
+                Buffs[i].Save(writer);
             }
 
             writer.Write(AutoPot);

--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -53,7 +53,7 @@ namespace Server.MirEnvir
         public static object LoadLock = new object();
 
         public const int MinVersion = 60;
-        public const int Version = 116;
+        public const int Version = 117;
         public const int CustomVersion = 0;
         public static readonly string DatabasePath = Path.Combine(".", "Server.MirDB");
         public static readonly string AccountPath = Path.Combine(".", "Server.MirADB");

--- a/Server/MirObjects/HeroObject.cs
+++ b/Server/MirObjects/HeroObject.cs
@@ -149,6 +149,7 @@ namespace Server.MirObjects
             if (Level == 0) NewCharacter();
 
             RefreshStats();
+            RefreshNameColour();
             SendInfo();
 
             switch (HP)
@@ -1201,6 +1202,7 @@ namespace Server.MirObjects
             {
                 ObjectID = ObjectID,
                 Name = Name,
+                NameColour = NameColour,
                 Class = Class,
                 Gender = Gender,
                 Level = Level,

--- a/Server/MirObjects/PlayerObject.cs
+++ b/Server/MirObjects/PlayerObject.cs
@@ -1845,6 +1845,9 @@ namespace Server.MirObjects
         {
             if (human == null) return NameColour;
 
+            // Heroes have a fixed, server-defined colour (do not apply PK/brown/warzone logic).
+            if (human is HeroObject hero) return hero.NameColour;
+
             if (human is PlayerObject player)
             {
                 if (player.PKPoints >= 200)
@@ -14486,6 +14489,9 @@ namespace Server.MirObjects
 
             if (Hero != null)
             {
+                // Sealing (marbling) a hero should wipe all buffs so they can't be stored/traded with remaining durations.
+                CurrentHero.Buffs?.Clear();
+
                 DespawnHero();
                 Info.HeroSpawned = false;
                 Enqueue(new S.UpdateHeroSpawnState { State = HeroSpawnState.None });

--- a/Shared/ServerPackets.cs
+++ b/Shared/ServerPackets.cs
@@ -4707,6 +4707,7 @@ namespace ServerPackets
         {
             ObjectID = reader.ReadUInt32();
             Name = reader.ReadString();
+            NameColour = Color.FromArgb(reader.ReadInt32());
             Class = (MirClass)reader.ReadByte();
             Gender = (MirGender)reader.ReadByte();
             Level = reader.ReadUInt16();
@@ -4756,6 +4757,7 @@ namespace ServerPackets
         {
             writer.Write(ObjectID);
             writer.Write(Name);
+            writer.Write(NameColour.ToArgb());
             writer.Write((byte)Class);
             writer.Write((byte)Gender);
             writer.Write(Level);


### PR DESCRIPTION
Tried to replicate proposed issue, Could not replicate.

If you shut down the server it would remove the Hero Buffs. Sorry @Suprcode included some more changes to this commit.

1. Hero buffs acts like Players buff on server restart/shutdown. (Retains the buffs)
2. Hero buff border to follow Official (Red border)
3. Hero Name to follow Official (Purple)
4. If you seal the Hero it will now remove the active buffs.

<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/5f7ad73a-ea47-42c8-a483-c5327a7b844e" />
