### PR TITLE
Guild Backup Sync

### DIFF
--- a/Server/MirEnvir/Envir.cs
+++ b/Server/MirEnvir/Envir.cs
@@ -2631,9 +2631,16 @@ namespace Server.MirEnvir
                 if (GuildList[i].NeedSave || forced)
                 {
                     GuildList[i].NeedSave = false;
-                    var mStream = new MemoryStream();
+
+					GuildObject liveGuild = Guilds.Find(g => g.Guildindex == GuildList[i].GuildIndex);
+					if (liveGuild != null)
+					{
+						GuildList[i] = liveGuild.Info;
+					}
+
+					var mStream = new MemoryStream();
                     var writer = new BinaryWriter(mStream);
-                    GuildList[i].Save(writer);
+					GuildList[i].Save(writer);
                     var fStream = new FileStream(Path.Combine(Settings.GuildPath, i + ".mgdn"), FileMode.Create);
                     var data = mStream.ToArray();
                     fStream.BeginWrite(data, 0, data.Length, EndSaveGuildsAsync, fStream);

--- a/Server/MirObjects/GuildObject.cs
+++ b/Server/MirObjects/GuildObject.cs
@@ -104,8 +104,11 @@ namespace Server.MirObjects
         {
             Info = info;
 
-            Envir.Guilds.Add(this);
-        }
+			if (!Envir.Guilds.Any(x => x.Guildindex == info.GuildIndex))
+			{
+				Envir.Guilds.Add(this);
+			}
+		}
 
         public void SendMessage(string message, ChatType Type = ChatType.Guild)
         {


### PR DESCRIPTION
Hi,

Thanks everyone for your work on Crystal. I have noticed an issue with Guild Storage where sometimes, after restarting the server (whether it be through Stop Server, Close Server/Pressing 'X' on Server window), the changes made to a Guild's exp&level status, storage items and sometimes member list, are not retained in the .mgd backups.

_Envir.cs_ - When SaveGuilds is called, and a Guild from Envir.Guilds is in the NeedSave status, the latest version of the Guild should be synced to its relative Guild in GuildList (in this case done via copy and replace, based on GuildIndex, assumed to always be unique if the Mir.ADB is unchanged).

_GuildObject.cs_ - Envir.Guilds is assumed to be created once when the application loads, and is not cleared until the application is fully closed. Subsequent stops and starts of the server without closing leads to duplicate instances of the same GuildObject in Envir.Guilds. In this case the change was to check, again by Guildindex, that only one representation of a Guild is present for players to load and interact with.

There are two ways in which backups get saved by Envir. One is after SaveDelay has passed, acting as autosave for mirdb, accounts, guilds etc. The other way is as graceful fallback to a thrown exception. For both cases, I have experienced sync issues when the guild makes some progress (gainexp, stored an item), but what is strange to me is that it is not a consistently replicable issue. There does seem to be some sync happening between the live player instance of the Guild (in Envir.Guilds) and the backup-related instance of the Guild (in Envir.GuildList), but wasn't able to understand how this currently works. However after applying these changes, I have tried hard to break the setup and could not, it seemed to work well with the auto-indexing and backup systems, regardless of whether the server is suddenly closed, or Stop Server is used.

Appreciate your feedback on this and hope it is helpful in some way.