### PR TITLE
HumanObject debugging fix

### DIFF
--- a/Server/MirObjects/HumanObject.cs
+++ b/Server/MirObjects/HumanObject.cs
@@ -8485,9 +8485,9 @@ namespace Server.MirObjects
             if (Connection == null) return;
             Connection.Enqueue(p);
 
-            //MessageQueue.EnqueueDebugging(((ServerPacketIds)p.Index).ToString());
-        }
-        public virtual void Enqueue(Packet p, MirConnection c)
+			//if (p != null) MessageQueue.EnqueueDebugging(((ServerPacketIds)p.Index).ToString());
+		}
+		public virtual void Enqueue(Packet p, MirConnection c)
         {            
             if (c == null)
             {


### PR DESCRIPTION
The call to MessageQueue.EnqueueDebugging in HumanObject causes an exception when trying to cast a potentially null packet (e.g. CannibalPlant's Packet GetInfo(), returning null when not visible).

The fix was to check for the null packet after any actual packets have been enqueued, since the Connection already ignores nulls.