### PR TITLE
fix Server Config Form CheckVersion checkbox

### DIFF
--- a/Server.MirForms/ConfigForm.Designer.cs
+++ b/Server.MirForms/ConfigForm.Designer.cs
@@ -241,6 +241,7 @@
             VersionCheckBox.TabIndex = 3;
             VersionCheckBox.Text = "Check for client version";
             VersionCheckBox.UseVisualStyleBackColor = true;
+			VersionCheckBox.CheckedChanged += VersionCheckBox_CheckedChanged;
             // 
             // VPathBrowseButton
             // 

--- a/Server.MirForms/ConfigForm.cs
+++ b/Server.MirForms/ConfigForm.cs
@@ -351,6 +351,11 @@ namespace Server
         {
             ProcessFiles(RequiredClass.Archer, false);
         }
-        #endregion
-    }
+		#endregion
+
+		private void VersionCheckBox_CheckedChanged(object sender, EventArgs e)
+		{
+			Settings.CheckVersion = VersionCheckBox.Checked;
+		}
+	}
 }


### PR DESCRIPTION
This setting was not being saved upon modification.

Added handler method and assignment to update the setting before a Save is carried out (e.g. on form close).